### PR TITLE
add GTK3 cups support

### DIFF
--- a/gtk-settings.ini
+++ b/gtk-settings.ini
@@ -1,0 +1,2 @@
+[Settings]
+gtk-print-backends=file,cups

--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -19,8 +19,40 @@ finish-args:
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Flatpak
+# gtk-cups-backend
+  - --env=GTK_PATH=/app/lib/gtkmodules
+  - --socket=cups
+  - --system-talk-name=org.freedesktop.Avahi
 modules:
   - shared-modules/libsecret/libsecret.json
+
+  - name: gtk-cups-backend
+    buildsystem: meson
+    make-args:
+      - modules/printbackends/libprintbackend-cups.so
+    no-make-install: true
+    post-install:
+      - install -Dm755 modules/printbackends/libprintbackend-cups.so -t /app/lib/gtkmodules/3.0.0/printbackends/
+      - install -Dm644 ../gtk-settings.ini /app/etc/xdg/gtk-3.0/settings.ini
+    sources:
+      - type: git
+        url: https://gitlab.gnome.org/GNOME/gtk.git
+        tag: 3.24.23
+      - type: file
+        path: gtk-settings.ini
+    modules:
+      - name: libcups
+        make-args:
+          - libs
+        no-make-install: true
+        post-install:
+          - make install-headers install-libs
+        cleanup:
+          - /include
+        sources:
+          - type: archive
+            url: https://github.com/apple/cups/releases/download/v2.3.3/cups-2.3.3-source.tar.gz
+            sha256: 261fd948bce8647b6d5cb2a1784f0c24cc52b5c4e827b71d726020bcc502f3ee
 
   - name: libvips
     cleanup:


### PR DESCRIPTION
This tries to add the GTK3 cups backend taking advantage of the [work that been already done for Chrome app](https://github.com/flathub/com.google.Chrome/commit/fe9e968e1b0a049be65eca7726a53edd53952140).  
I haven't tried building this, I'm letting the CI do it that, so this is still untested.  
Closes #1.