### PR TITLE
Remove org.freedesktop.flatpak bus

### DIFF
--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -21,7 +21,6 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar
-  - --talk-name=org.freedesktop.Flatpak
 # gtk-cups-backend
   - --env=GTK_PATH=/app/lib/gtkmodules
   - --socket=cups


### PR DESCRIPTION
The org.freedesktop.flatpak bus allows the application to acquire any permissions it wants, breaking the sandbox.

Joplin has no need to talk with this bus to function correctly as far as I know.

Closes #25 
Closes #6 