### PR TITLE
Update flatpak permissions

### DIFF
--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -12,11 +12,12 @@ rename-desktop-file: joplin.desktop
 command: joplin-desktop
 finish-args:
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
   - --device=dri
   - --share=ipc
   - --share=network
-  - --filesystem=home
+  - --filesystem=xdg-config/joplin-desktop
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar


### PR DESCRIPTION
Joplin works fine on Wayland, so it should only use X11 if Wayland isn't available. Joplin also doesn't need access to the entire home directory. It works quite well with access to only `xdg-config/joplin-desktop`, where its database is stored. (Files and images can also still be attached.) I think for syncing with local folders, we should recommend using Flatseal — which is required anyway if the folder is on an external/network drive.