### PR TITLE
Wayland works, so enable Wayland permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,6 @@ flatpak override --filesystem=host net.cozic.joplin_desktop
 ```
 Note: You can also use multiple `filesystem` options to set `/media`,`/run/media`,`/mnt` as you need.
 
-## Fractional scaling under Wayland
-
-Wayland support is already implemented but disabled by default.
-
-You can enable it with [Flatseal](https://flathub.org/apps/com.github.tchx84.Flatseal) by checking the "Wayland windowing system" toggle or by running the command below: 
-
-```bash
-flatpak override -u net.cozic.joplin_desktop --socket=wayland
-``` 
-
 ## Use external editor with flatpak
 There are two ways.
 ### xdg-open

--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -12,7 +12,7 @@ rename-desktop-file: joplin.desktop
 command: joplin-desktop
 finish-args:
   - --socket=pulseaudio
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --device=dri
   - --share=ipc

--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -13,6 +13,7 @@ command: joplin-desktop
 finish-args:
   - --socket=pulseaudio
   - --socket=x11
+  - --socket=wayland
   - --device=dri
   - --share=ipc
   - --share=network


### PR DESCRIPTION
If Wayland doesn't work for you, let me know, but it works completely fine on AMD, Intel, and NVIDIA for me. The only thing stopping it by default is the lack of permissions.

This would be useful for me and (I presume) many others since it would allow nicer scaling and remove another app that requires Xwayland.