### PR TITLE
Update Joplin to 3.4.12

### DIFF
--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -102,8 +102,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/laurent22/joplin/archive/v3.3.12.tar.gz
-        sha256: 0a12596230ab98632fd1324e35014ceb471172d60c9b4b2e95dff3da20a47931
+        url: https://github.com/laurent22/joplin/archive/v3.4.12.tar.gz
+        sha256: c00ac2540371543d85b4362fd716ff4748f18a61276d137cad91d318cd30f744
         x-checker-data:
           type: json
           url: https://api.github.com/repos/laurent22/joplin/releases/latest


### PR DESCRIPTION
This PR updates Joplin to 3.4.12, which is the latest version at this time. It is in response to #283 to ensure that the version of Joplin packaged here is at the latest version.

Note: if preferred, I am willing to take over maintenance of it because I actively use Joplin for my school notes. At least, I can take over maintenance until an official developer decides to take it over. I say this because it appears that there might be a backlog of work, and since I use Joplin on a daily basis, I can assist with getting some of this work done.