### PR TITLE
Restrict filesystem permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## File system sync on removable-media
-This flatpak only have permission to access user's home directory.  
+This Flatpak only has access to the Joplin config and backup directories by default.
 Need to manually add permission to allow access other location. 
 
 

--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -17,7 +17,8 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --share=network
-  - --filesystem=home
+  - --filesystem=xdg-config/joplin-desktop
+  - --filesystem=~/JoplinBackup
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar


### PR DESCRIPTION
## Summary

Access to the entire home directory is unnecessary, and with this small change, you can restrict it as much as possible without any drawbacks.

The Flatpak now only grants access to:
* `xdg-config/joplin-desktop`
* `~/JoplinBackup`

In addition, the README has been updated to reflect this change

## Changes

* remove `--filesystem=home`
* add restricted filesystem permissions for config and backup paths
* update readme

## Benefits

* reduced host filesystem exposure

