### PR TITLE
Restrict filesystem access to Joplin config and backup dirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## File system sync on removable-media
-This flatpak only have permission to access user's home directory.  
-Need to manually add permission to allow access other location. 
+This flatpak only has access to Joplin's config and backup directories by default.
+Need to manually add permission to allow access other location.
 
 
 You can do it with [Flatseal](https://flathub.org/apps/details/com.github.tchx84.Flatseal), and configure permissions with nice gui.  

--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -17,7 +17,8 @@ finish-args:
   - --device=dri
   - --share=ipc
   - --share=network
-  - --filesystem=home
+  - --filesystem=~/.config/joplin-desktop:create
+  - --filesystem=~/JoplinBackup:create
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
   - --talk-name=com.canonical.AppMenu.Registrar


### PR DESCRIPTION
Replace broad --filesystem=home with scoped access to ~/.config/joplin-desktop and ~/JoplinBackup, the only two paths Joplin actually hardcodes. Both use :create since Joplin creates these directories itself on first run rather than expecting them to pre-exist.