### PR TITLE
Update Joplin to 3.7.18

### DIFF
--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,45 +1,10 @@
 [
     {
         "type": "archive",
-        "url": "https://playwright.azureedge.net/builds/chromium/1200/chromium-headless-shell-linux.zip",
-        "strip-components": 0,
-        "sha256": "a9a525cb3832d59a810f78f8ba6c5ed3592a6a488984627f5d827c2a365c8a5a",
-        "dest": "flatpak-node/cache/ms-playwright/chromium-headless-shell-1200"
-    },
-    {
-        "type": "archive",
-        "url": "https://playwright.azureedge.net/builds/chromium/1200/chromium-linux.zip",
-        "strip-components": 0,
-        "sha256": "ab56b2a7955c2961f74348e2349f1e907489283da23dba37c730b624e4d670bb",
-        "dest": "flatpak-node/cache/ms-playwright/chromium-1200"
-    },
-    {
-        "type": "archive",
-        "url": "https://playwright.azureedge.net/builds/ffmpeg/1011/ffmpeg-linux.zip",
-        "strip-components": 0,
-        "sha256": "ebc74fc5b94830176a3c2914ae96bd8bc7f6a91f4f33890230f84a172ee61ccc",
-        "dest": "flatpak-node/cache/ms-playwright/ffmpeg-1011"
-    },
-    {
-        "type": "archive",
-        "url": "https://playwright.azureedge.net/builds/firefox/1497/firefox-ubuntu-22.04.zip",
-        "strip-components": 0,
-        "sha256": "4840492ad5bb2585db35c68c2d385d22708d23a04a12593f4553e7b769be3a03",
-        "dest": "flatpak-node/cache/ms-playwright/firefox-1497"
-    },
-    {
-        "type": "archive",
-        "url": "https://playwright.azureedge.net/builds/webkit/2227/webkit-ubuntu-24.04.zip",
-        "strip-components": 0,
-        "sha256": "e5a1ba6010d3d3b71819b294185131e427f00f48b4ccaa55c640e08d61f6a64f",
-        "dest": "flatpak-node/cache/ms-playwright/webkit-2227"
-    },
-    {
-        "type": "archive",
-        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
         "strip-components": 1,
-        "sha512": "bd67eae0668830ff4021ee328f56545b5f110e1c7a10f40a8f07bb9fc05b21e705b42406e027c719a1ee87b7dd7eafb2dcb200daf192fe8f590465712038bd87",
-        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.27.2",
+        "sha512": "d30915ad81c6e2c74208dfdb73043bc9831700291a1dcdd415e6843b04955ba7b947270c6a0798005bfe252d9b28bc07c9e29552fb68547fb9fd11ead1f81e17",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.27.5",
         "only-arches": [
             "arm"
         ]
@@ -56,10 +21,10 @@
     },
     {
         "type": "archive",
-        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
         "strip-components": 1,
-        "sha512": "858c4df29afae8db020a2445907500b31ca534e70041ac524a41cc323729c74b22d77b752c71698712595221b0a230756bf1dde4e88f22a0dd5ce3626ba6e14f",
-        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.27.2",
+        "sha512": "7ae2a48a5b0d3afef1fccd4d2acc79ce7ca9adba6c4452334d5ea55b38aa25c87bc9661ac9f2ed6730f10d397e2d240325802377d4d56ff2ade54288ae3d9ee0",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.27.5",
         "only-arches": [
             "aarch64"
         ]
@@ -76,10 +41,10 @@
     },
     {
         "type": "archive",
-        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
         "strip-components": 1,
-        "sha512": "309b7905145249c3c3c06da12de95884000a87d8a68c72b9f8d13fb6f9d12db22a5166bed04f4de1634c8e6a7f9175cf1d91aa3cbc60830561cfb40ff024d1f3",
-        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.27.2",
+        "sha512": "8554505f8f8fdcc4b7e8dc4ecb6e2ffc276c8a6cbfe4761e3f0fad98faa734dd5fc55d1b3eb15647a4ccab05cfc284ccd95cdb900fb895b1d650a0dde590c0ff",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.27.5",
         "only-arches": [
             "i386"
         ]
@@ -96,10 +61,10 @@
     },
     {
         "type": "archive",
-        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
         "strip-components": 1,
-        "sha512": "bb0a764e2a7968f987f8d454c1371f2dbf96df65978e915e8d320e599170fefeff2a7a420ca1baeaee032dcbab4298984e263043d07b28e78c26f2c2bbf3af6c",
-        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.27.2",
+        "sha512": "f86ab8ed6aaae8f2ce399b81cd5488236ffff72c8734a64bbb07f309e9aa7b1a8e4024b3d33cb43b6ea4233ca9f4430d30afa7674b451c166b09e554b8cb3f7b",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.27.5",
         "only-arches": [
             "x86_64"
         ]
@@ -116,16 +81,16 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v40.8.3/SHASUMS256.txt",
-        "sha256": "4c146cc44836beac1cb8592ebdf22dc81a34961bd56a3a956a6a439063f9371d",
-        "dest-filename": "SHASUMS256.txt-40.8.3",
+        "url": "https://github.com/electron/electron/releases/download/v42.3.0/SHASUMS256.txt",
+        "sha256": "d657324903da9e661601ef0c337eb643fc5eceee8c86b837f25cd9a6691a407a",
+        "dest-filename": "SHASUMS256.txt-42.3.0",
         "dest": "flatpak-node/cache/electron"
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v40.8.3/electron-v40.8.3-linux-arm64.zip",
-        "sha256": "73231830b8cc57f2a591892ca02a66b551fd5f3ffe53a7d97c334b7c37c426a1",
-        "dest-filename": "electron-v40.8.3-linux-arm64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v42.3.0/electron-v42.3.0-linux-arm64.zip",
+        "sha256": "2a375ff973fb7bddc538a4f67b2141947e9d72513a1baa2beabec2a7f65cd0f0",
+        "dest-filename": "electron-v42.3.0-linux-arm64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "aarch64"
@@ -133,9 +98,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v40.8.3/electron-v40.8.3-linux-armv7l.zip",
-        "sha256": "0871b376645b2016889b01567849a74f866c381d7c0acaf38cd7e9cc57d4df83",
-        "dest-filename": "electron-v40.8.3-linux-armv7l.zip",
+        "url": "https://github.com/electron/electron/releases/download/v42.3.0/electron-v42.3.0-linux-armv7l.zip",
+        "sha256": "5d15e602d978d53772ec0c58af4ef02d1ba514dc3d6752ffe79c0ad21804c38c",
+        "dest-filename": "electron-v42.3.0-linux-armv7l.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "arm"
@@ -143,9 +108,9 @@
     },
     {
         "type": "file",
-        "url": "https://github.com/electron/electron/releases/download/v40.8.3/electron-v40.8.3-linux-x64.zip",
-        "sha256": "eda4c724c24d57072e182db6f4f7fcd89d57fbe6179a32a7a8b947ff77eb2a95",
-        "dest-filename": "electron-v40.8.3-linux-x64.zip",
+        "url": "https://github.com/electron/electron/releases/download/v42.3.0/electron-v42.3.0-linux-x64.zip",
+        "sha256": "487a667ca6a734b958c16cff1df74d9d44d2c18a6cccdb4dd51f6301a356c420",
+        "dest-filename": "electron-v42.3.0-linux-x64.zip",
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
             "x86_64"
@@ -503,13 +468,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/client-ses/-/client-ses-3.932.0.tgz",
-        "sha512": "2dba7da419bbfe2d58f120842539cdf96aac3ff43a425d0ee1dbb8f1d4980da126f7dfe92eace49bfbbb070d4d1c63b30ca08c2c23070c2a9adc83ac3eb452b7",
-        "dest-filename": "client-ses-QGF3cy1zZGsvY2xpZW50LXNlc0BucG06My45MzIuMA==-05d6191b91.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.296.0.tgz",
         "sha512": "191c9c0957651480af5b0bfdcfa31cff606f4813af72158eed44e496f6ca5de0e7e83d390bed363dfc5ea2870c4dce2bf3f785a04416b3aee1e6efe53e9c870f",
         "dest-filename": "client-sso-oidc-QGF3cy1zZGsvY2xpZW50LXNzby1vaWRjQG5wbTozLjI5Ni4w-c2bb6d6cee.tgz",
@@ -527,13 +485,6 @@
         "url": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.928.0.tgz",
         "sha512": "11f7a76fccd5d9f2490d79a9d8d138c63f189a1a78815242910ea2c6176ba5f41781dd8f3833bb6b6d02dbe06114ce9a1a63779ba5d6609eb8672857178a40c9",
         "dest-filename": "client-sso-QGF3cy1zZGsvY2xpZW50LXNzb0BucG06My45MjguMA==-39c3ad9aff.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.932.0.tgz",
-        "sha512": "5c7a876b98afd8e42c2a8336b54417b3b100cabca99680b4d168345d216b6bf2802aac868b351be57c57b06972aa179b076f56aaeafecf0891c0d99e8e6374f9",
-        "dest-filename": "client-sso-QGF3cy1zZGsvY2xpZW50LXNzb0BucG06My45MzIuMA==-230adc3616.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -559,13 +510,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.932.0.tgz",
-        "sha512": "012f20ca961009b3688f0823bd91a4268702d82a042020f1f59275e482ecbfe32570254bb54252452c7757324e518d841086862d1acf36522aca7ffdfdfc92bc",
-        "dest-filename": "core-QGF3cy1zZGsvY29yZUBucG06My45MzIuMA==-79c0f8244a.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.296.0.tgz",
         "sha512": "783592537a74e20cad9245579d89f4e58ceb3f94846a3fc342269f778cbe88197c2057c5df333af7cdabb3aa8586fa70ac77926cba8735f291d470d65707c6e6",
         "dest-filename": "credential-provider-env-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1lbnZAbnBtOjMuMjk2LjA=-ee343c8384.tgz",
@@ -580,23 +524,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.932.0.tgz",
-        "sha512": "a3381efdcecd747503c87aaba3af8fe681edf307ca49404dfa896db6255f05ef4cc37c013293dade0434a599c6fa0c0190ab2406e8a9d9b311d7ab6a62f51210",
-        "dest-filename": "credential-provider-env-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1lbnZAbnBtOjMuOTMyLjA=-c3a92f9b6a.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.928.0.tgz",
         "sha512": "ebbca70bff145bd63c1a7d5966d0b73a07100c65ab25e9479a46e0a669b1614af3561a7e34836dcf7c224f3aeb04584f1fff14cba071be131f5e19f4a6d70c11",
         "dest-filename": "credential-provider-http-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1odHRwQG5wbTozLjkyOC4w-3101003781.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.932.0.tgz",
-        "sha512": "6fa37d367960f09227430cc1914ab9b2935a5ecb0cde1df32f11b3a4fae7c349c748858f24f4db67303909adbce5f703505b8a3fea9fdea92eaa502318e75686",
-        "dest-filename": "credential-provider-http-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1odHRwQG5wbTozLjkzMi4w-73fc1dfb46.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -622,13 +552,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.932.0.tgz",
-        "sha512": "6418d2017546cbb75a9d944709130943bb01906d43cf7f6d85896f4e251a7fd04a67ef3299e88586e4de5753a45940419d8d248b6755649bdba13a9f20d84dc4",
-        "dest-filename": "credential-provider-ini-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1pbmlAbnBtOjMuOTMyLjA=-d7bf253645.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.296.0.tgz",
         "sha512": "a029268766f50d084792177fa80f6389220e92b0412bb70c835fcf54880bc3c7b5e4d93350704e6cb27f650c3a6730b16738e5318685bfda0207c8723bcb7198",
         "dest-filename": "credential-provider-node-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1ub2RlQG5wbTozLjI5Ni4w-cccea41689.tgz",
@@ -639,13 +562,6 @@
         "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.928.0.tgz",
         "sha512": "49d5d58f164e21779f211fcd271fa5c973ab9f89b449c4c0536257a4bb050a45b609a7e8eaf4ea1d4821c8ef2f6a4fd743c3e93eaa4b5d5a466c0605b883d6e9",
         "dest-filename": "credential-provider-node-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1ub2RlQG5wbTozLjkyOC4w-6be8dc56fd.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.932.0.tgz",
-        "sha512": "4841bdb76b5a053f3aa9ede04ee9dfacaf01c53ef5d0654b19ea6f1ebf97e4fc3ea96db6e62351686374cc91fe644fe3f75b5c5bdc0e688a169d4464851e7022",
-        "dest-filename": "credential-provider-node-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1ub2RlQG5wbTozLjkzMi4w-be50ea4296.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -664,13 +580,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.932.0.tgz",
-        "sha512": "06875960abd3e29fc3926dbc425fc5843752d7ea79d5b71978c32ed9346d53c3e83031e7543847cf6ef301210a499c2686faaec47ad91c1d081ae56a8d952d49",
-        "dest-filename": "credential-provider-process-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1wcm9jZXNzQG5wbTozLjkzMi4w-7632d9a1b7.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.296.0.tgz",
         "sha512": "ccf1470d7fe78977dc42b29086606fd573d811ee1bee29b8bd12abce36178034691b63372cfd0a69623037a029f8645804d06d85e9fceaf853966286cf253960",
         "dest-filename": "credential-provider-sso-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1zc29AbnBtOjMuMjk2LjA=-464e717f0f.tgz",
@@ -685,13 +594,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.932.0.tgz",
-        "sha512": "5d89a4bfe96d0638e63d9e80991d594199107c3d2ecc6eb5335f3f2e27f71c01b1ca0ddd9a8774696c7d68bea58fd4afc401aacec72bc798f83e480baa366bbb",
-        "dest-filename": "credential-provider-sso-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci1zc29AbnBtOjMuOTMyLjA=-4dea861136.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.296.0.tgz",
         "sha512": "465e8e8687a4c5efa971c039e575d00d6e700296e0deb196afa16498f45c83b2dde957def872fc3ad7ec15ff37ff47a815eadebdb89ffb4d017649d7593d392c",
         "dest-filename": "credential-provider-web-identity-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci13ZWItaWRlbnRpdHlAbnBtOjMuMjk2LjA=-d3a81d423d.tgz",
@@ -702,13 +604,6 @@
         "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.928.0.tgz",
         "sha512": "addf7b9cb6397bf9c63abef765fb170fe1f8e2267dc321994cab7fd9092204dde1a2dfe2761813f7e5c7b168518bea3f7538506e92fc464a409e917ed191ad87",
         "dest-filename": "credential-provider-web-identity-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci13ZWItaWRlbnRpdHlAbnBtOjMuOTI4LjA=-a09377f8eb.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.932.0.tgz",
-        "sha512": "630fe160d9c2d4a1ee548405f4f90b5dbb8a37b963c7bd0e49b2580d1b9f96542f7a3de447035ca904a7cc8d4ce0a68e6dc72a29a13ab2b836d83aa93f2f69f3",
-        "dest-filename": "credential-provider-web-identity-QGF3cy1zZGsvY3JlZGVudGlhbC1wcm92aWRlci13ZWItaWRlbnRpdHlAbnBtOjMuOTMyLjA=-917c8a8b47.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -867,13 +762,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.930.0.tgz",
-        "sha512": "c77d239a6dd32eeedbfdbfbaee7332a15d0d95b9c2553e43239ef20eb85700f0ad7603352ad74b5ade3951c1e928e9b526c688926611876598bbb027c78306d2",
-        "dest-filename": "middleware-host-header-QGF3cy1zZGsvbWlkZGxld2FyZS1ob3N0LWhlYWRlckBucG06My45MzAuMA==-3c7efd1868.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.296.0.tgz",
         "sha512": "287916688ad93ad266575fd63bd28e7fb9122b8d6781faadb37608ba7f79e8d62094a4c32b2ac120e3c28265d34ffd37a1d9d8b0a553fd47db10887fbf847118",
         "dest-filename": "middleware-location-constraint-QGF3cy1zZGsvbWlkZGxld2FyZS1sb2NhdGlvbi1jb25zdHJhaW50QG5wbTozLjI5Ni4w-ef3b261d03.tgz",
@@ -902,13 +790,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.930.0.tgz",
-        "sha512": "be1e09056ccc0815bcc1112f030a12a81da078ab19c121d36b49d2b7438c38ba763dd4d82190e2d19895326a5f9e3731f576d2e9a4a5b8bbfdb0ac7846b1b8e8",
-        "dest-filename": "middleware-logger-QGF3cy1zZGsvbWlkZGxld2FyZS1sb2dnZXJAbnBtOjMuOTMwLjA=-04f3e1180f.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.296.0.tgz",
         "sha512": "506ed32c33f3f489901b4b959251d3c44f54b3bad3226c0dfba7a5eaa642a684c1b8679780e91f6f4fe9f22cc9c85818fe1314478719aacec87420d4931405df",
         "dest-filename": "middleware-recursion-detection-QGF3cy1zZGsvbWlkZGxld2FyZS1yZWN1cnNpb24tZGV0ZWN0aW9uQG5wbTozLjI5Ni4w-07686d11f2.tgz",
@@ -919,13 +800,6 @@
         "url": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.922.0.tgz",
         "sha512": "4ed482103a2757ff51d15855942a7165ba7ff6cc50bd34d12b321ff0bc56dee5e96f2e9697c23111c881265c664a4a2ac61e78d9645c928ecd60e0e5bcbfe00c",
         "dest-filename": "middleware-recursion-detection-QGF3cy1zZGsvbWlkZGxld2FyZS1yZWN1cnNpb24tZGV0ZWN0aW9uQG5wbTozLjkyMi4w-82e7c19ad5.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.930.0.tgz",
-        "sha512": "82fd2c7a43696b6301b08866d9c8cfde799849f2389ec731ffe2bdbbdc9bad6641594202e242f6b15fbe6c58e3533e10c54225bca072a30dff6bd0114320aeed",
-        "dest-filename": "middleware-recursion-detection-QGF3cy1zZGsvbWlkZGxld2FyZS1yZWN1cnNpb24tZGV0ZWN0aW9uQG5wbTozLjkzMC4w-edda22afc9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -1007,23 +881,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.932.0.tgz",
-        "sha512": "f411936c9c80ff83d377041613d840148246a6c624c845b6d1638dde2d79683aa8e68459c199aa6956a078e0f9ed862a1bc243263bdcc0ac83751e1c737f1dbe",
-        "dest-filename": "middleware-user-agent-QGF3cy1zZGsvbWlkZGxld2FyZS11c2VyLWFnZW50QG5wbTozLjkzMi4w-b377448985.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.928.0.tgz",
         "sha512": "917cdf264ab6703eb92801c37b88590ac9f1706184583e698c7a9c6699701b854531afe2567fe65ab518f5075a743d860695c53506e03a2286dd4d8d90abbee1",
         "dest-filename": "nested-clients-QGF3cy1zZGsvbmVzdGVkLWNsaWVudHNAbnBtOjMuOTI4LjA=-b454aa3fe3.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.932.0.tgz",
-        "sha512": "136b9c05f8974a9c597e51d37f75056d5c1aa38fbbbfb72d01e83c496ba095cd5432a325a703051605a248e36db1fd12477f990e8586013c825ce7c359eac9bb",
-        "dest-filename": "nested-clients-QGF3cy1zZGsvbmVzdGVkLWNsaWVudHNAbnBtOjMuOTMyLjA=-a3044b6536.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -1073,13 +933,6 @@
         "url": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.925.0.tgz",
         "sha512": "14eb6171d17da036f5a5f4014427d63d9849653e70aa9bdd012e5a27307558367ee84b9a0212f32c7fdf5b5b250ee9c8aaad4f490186dee4a756095554ebcf1d",
         "dest-filename": "region-config-resolver-QGF3cy1zZGsvcmVnaW9uLWNvbmZpZy1yZXNvbHZlckBucG06My45MjUuMA==-d0726500c7.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.930.0.tgz",
-        "sha512": "28bd8966a1fa698790b2cbb58352ae5ac45eba975f3a8c43e9fd5ab36542fab77060552ee0b7f332c15f5e706fbd0596a90eeb64758ec354fea398099a0ec3cf",
-        "dest-filename": "region-config-resolver-QGF3cy1zZGsvcmVnaW9uLWNvbmZpZy1yZXNvbHZlckBucG06My45MzAuMA==-3172f67449.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -1147,13 +1000,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.932.0.tgz",
-        "sha512": "e37bbcdae955b872b8cd685c48fcae3d2d7c9742cd1e2dd0250d58b4fd8c7cff1b3dfe5aea1318a797b7954afda130c459ca70058b4e5b49b50d59a853fdef78",
-        "dest-filename": "token-providers-QGF3cy1zZGsvdG9rZW4tcHJvdmlkZXJzQG5wbTozLjkzMi4w-07d12bfda3.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.296.0.tgz",
         "sha512": "b34c0869ceb8aeb304a368a85313fd21aac68a208699e942b2935ca0d4cf4a31a5db942a8e1c9f42a4de1a04b9f2a2787c7a106f4eeaadadfdf77d31a7523326",
         "dest-filename": "types-QGF3cy1zZGsvdHlwZXNAbnBtOjMuMjk2LjA=-4234902992.tgz",
@@ -1171,13 +1017,6 @@
         "url": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.922.0.tgz",
         "sha512": "78b03a5e35686c0500322bef33b0c12fbf669c7cab9bedf64e45cd599b9ae669f117eea44027db94a289bf13192c6a2c3b9dff131e3aa208a6f0863935baafdb",
         "dest-filename": "types-QGF3cy1zZGsvdHlwZXNAbnBtOjMuOTIyLjA=-1ed9b69a8d.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.930.0.tgz",
-        "sha512": "c1efef680830944156ec879fb6608b94b330fba845b370f364f270ee55476e3ff91c9d1bcfd82777112c4b6950a1e275ce18a22ea02abd7c66338decd0c060d0",
-        "dest-filename": "types-QGF3cy1zZGsvdHlwZXNAbnBtOjMuOTMwLjA=-e0cdce3106.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -1273,13 +1112,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.930.0.tgz",
-        "sha512": "336a04281cf334062bd77e9145ceaeab0dda5a5c02c6a4cfd4b6b0a6cf44d5dd9a6d13ef975a75ced426997a75024e2bbfc781c8867ec90c8a437ccf7511b977",
-        "dest-filename": "util-endpoints-QGF3cy1zZGsvdXRpbC1lbmRwb2ludHNAbnBtOjMuOTMwLjA=-c18927641a.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.296.0.tgz",
         "sha512": "09c6040b39140271cbe6adeec8f89c69f9f6398d068a494861fb8e5073d9ff814cc487ac7750670830d18d3945c4b5a3b8dba28a121dc01ed06f5a43cf173723",
         "dest-filename": "util-format-url-QGF3cy1zZGsvdXRpbC1mb3JtYXQtdXJsQG5wbTozLjI5Ni4w-7b54e582b9.tgz",
@@ -1350,13 +1182,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.930.0.tgz",
-        "sha512": "aba942466e9401ef9ed4b82e33913812a33d6eb4250de9b85c3710f3b37312f9535ba1b398d08ed30d634b45e00855d01e30f18dd94d157fb9b116c78a3c2496",
-        "dest-filename": "util-user-agent-browser-QGF3cy1zZGsvdXRpbC11c2VyLWFnZW50LWJyb3dzZXJAbnBtOjMuOTMwLjA=-bda30e8deb.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.296.0.tgz",
         "sha512": "00c59a73c68806769af67c4012967be768f6f5afd441356245f479827097dfc10204a19f3903298189de7b91dd94caf8187263d1690ecd0c41b489d6e29579f2",
         "dest-filename": "util-user-agent-node-QGF3cy1zZGsvdXRpbC11c2VyLWFnZW50LW5vZGVAbnBtOjMuMjk2LjA=-f67700a102.tgz",
@@ -1367,13 +1192,6 @@
         "url": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.928.0.tgz",
         "sha512": "b348cfebb9d02cb59559f06da939195244962b97ba388fabb3ec05c9ada1f552f2581162af5ed748323cf75b3c1d9288542125f1e06bba9fa1872c26e27b0800",
         "dest-filename": "util-user-agent-node-QGF3cy1zZGsvdXRpbC11c2VyLWFnZW50LW5vZGVAbnBtOjMuOTI4LjA=-f8df1ede06.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.932.0.tgz",
-        "sha512": "fe40ba72c707ad92fbe13ad9b608882f98c935b56cc3d76e1863eeae669582809b3fb367c72692584bab6cd57754f34f84d1376d5de0e028bea1dabe025b1842",
-        "dest-filename": "util-user-agent-node-QGF3cy1zZGsvdXRpbC11c2VyLWFnZW50LW5vZGVAbnBtOjMuOTMyLjA=-82efdfb2b9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -1413,13 +1231,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
-        "sha512": "6087e40f5ec6a1cc5d9a551573789ae76421716b912142689db17c0360987dc58d5771f3bc0aa970f782d1b6148642bef1ef183b50119cb299404d13970ce8ac",
-        "dest-filename": "xml-builder-QGF3cy1zZGsveG1sLWJ1aWxkZXJAbnBtOjMuOTMwLjA=-7956588f54.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.1.1.tgz",
         "sha512": "45c2da9b5ecb7656d2392a7d571994bb5788e8cc31a7e3b0843d9086248d98d0b3a036f411e5174c3da7fd66dc9eb0183069667f4e6d87a418ab6dd5aaf26aa4",
         "dest-filename": "lambda-invoke-store-QGF3cy9sYW1iZGEtaW52b2tlLXN0b3JlQG5wbTowLjEuMQ==-6285352610.tgz",
@@ -1427,9 +1238,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.0.tgz",
-        "sha512": "ef4bc14ff625aa99bae51433da2086da8d09242106fd608dc9e7d3af6c5c39caf50a849e7bad2035061431967b62e9282a414bbf6e88fe38e5b2fc30a79df6a1",
-        "dest-filename": "playwright-QGF4ZS1jb3JlL3BsYXl3cmlnaHRAbnBtOjQuMTEuMA==-54de38082d.tgz",
+        "url": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+        "sha512": "87f91f92cbf817471520394aa53e3bd3439e85d460a6fb95b24b90da76fbfc99ad5945e97bd7ed1c03edc325c6bd54ac6ba489eb803d111ed9af373fb08bc2e3",
+        "dest-filename": "playwright-QGF4ZS1jb3JlL3BsYXl3cmlnaHRAbnBtOjQuMTEuMw==-6da87fce93.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -1437,13 +1248,6 @@
         "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
         "sha512": "bc6e92bc1ea860486f822b193454664425242f3d7573bae9fad6cd4f29c6a9cea64b577901377fb06c95e96d0a6599d744a313cd90d18104f73aef6386901f52",
         "dest-filename": "code-frame-QGJhYmVsL2NvZGUtZnJhbWVAbnBtOjcuMTAuNA==-4ef9c67951.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-        "sha512": "66dd72a1d071d5473289e3cc4a45a753884faa1c2aee11a2da714bd4b780dc4525faad8b431d7a3084a0274fb3edd9e682f3fd42d2257ae11318e88e1f545c23",
-        "dest-filename": "code-frame-QGJhYmVsL2NvZGUtZnJhbWVAbnBtOjcuMTIuMTE=-d243f0b1e4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -4332,13 +4136,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
-        "sha512": "2dcf7814e0f9fb469785d6f44dd837454b6a4fac966c8fc16c55af95a489de001bf4ab3ef7d9c74432800d5a82dfb7abe1e081d1f1f2593fb2f8add03af24a6f",
-        "dest-filename": "runtime-corejs3-QGJhYmVsL3J1bnRpbWUtY29yZWpzM0BucG06Ny4yOS4y-0907bbc8a5.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
         "sha512": "79c8ef6259c0699fca567784fce74a60161f8175773edbbacd05a680417bbf02a1427bd54ba6e3303d976208fe48dbd0d467cafe98e0a247cf902ff608ef02b8",
         "dest-filename": "runtime-QGJhYmVsL3J1bnRpbWVAbnBtOjcuMjIuNQ==-994898ec8e.tgz",
@@ -4605,16 +4402,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
-        "sha512": "6cec2f4ce209706e45568e60514ba98b0621f0c8a83cb43851ca9b7117fb510f7c5fdd2d09af44d6467767bb6ac296716323af87561361b99913d4537d3a7986",
-        "dest-filename": "autocomplete-QGNvZGVtaXJyb3IvYXV0b2NvbXBsZXRlQG5wbTo2LjIwLjA=-ba3603b860.tgz",
+        "url": "https://registry.npmjs.org/@clack/core/-/core-1.4.0.tgz",
+        "sha512": "ed672d8eae9fedcd423f3f2c3e9930527cfcc9181500d92936ea5bf35ab8df616370983897e4b0ed700d74d49d59f00aab420723425371478ae5dc6cfc7ac63f",
+        "dest-filename": "core-QGNsYWNrL2NvcmVAbnBtOjEuNC4w-dad478b31d.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.1.tgz",
-        "sha512": "b960d6172a4d7509b3db2d4b68d2732bb7cbed360a2de5005349e9102ebce4e29317729c43656ede494833bf03ec8eb01a192d99ed258770ae40bbf4642ac3f5",
-        "dest-filename": "commands-QGNvZGVtaXJyb3IvY29tbWFuZHNAbnBtOjYuMTAuMQ==-9e305263dc.tgz",
+        "url": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.0.tgz",
+        "sha512": "c0a87ec138e6ad4a14764660f0aa493b95fea7d3d657e284f6678fb1eabd5185a4ba48132ac192e3b4512f61ecb7055cbc3407f8f7a7acf256208f3e31f8a2c8",
+        "dest-filename": "prompts-QGNsYWNrL3Byb21wdHNAbnBtOjEuNS4w-1503a134a6.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+        "sha512": "d5cbe0dd5cf5752493a0236525f440d96488e21b772be5a994ed1430e8265183e2bc2cb2da8b9e658e8bc7b33dc13866ed20d40558919ae4fe386fe2f3e38df4",
+        "dest-filename": "autocomplete-QGNvZGVtaXJyb3IvYXV0b2NvbXBsZXRlQG5wbTo2LjIwLjE=-e57d78bb46.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+        "sha512": "245462aa12aef9bbd29032c8fab5212704b143161bef9f56e4605ecc4f1473c9872ea0bd695ffd6930bbc894aa0ad077174d29ca5acb0b09f24bdd40a797a3e1",
+        "dest-filename": "commands-QGNvZGVtaXJyb3IvY29tbWFuZHNAbnBtOjYuMTAuMw==-2740c95cc7.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -4752,9 +4563,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.4.tgz",
-        "sha512": "aa3b7b5a7fe7c46b88dbbf0661596a13957ddd79fc650c33a99b604b415a5abecadb25a0779fc594136a362e23b54bc156f589cc019f9e0808969ca34ce685e0",
-        "dest-filename": "language-QGNvZGVtaXJyb3IvbGFuZ3VhZ2VAbnBtOjYuMTAuNA==-73b7404adc.tgz",
+        "url": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+        "sha512": "4300995ba4edd6c88fdfb25eb7d4dbd3666cf354d0b7aa90ad94761fe78631c16c2f5cccae4dbf6fd08b0bbffd89e3f57e3214320be22d63268221e826b8fe64",
+        "dest-filename": "language-QGNvZGVtaXJyb3IvbGFuZ3VhZ2VAbnBtOjYuMTIuMw==-d33f273613.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -4766,30 +4577,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
-        "sha512": "b2fdc3ca50622328bec4ac11089000b01659656a3cdac849fd14ccca62da6c076d6e45797122b058378282d52adeff1f9536974b6cb590a9080ae458b54b30c9",
-        "dest-filename": "lint-QGNvZGVtaXJyb3IvbGludEBucG06Ni45LjI=-22e04e2547.tgz",
+        "url": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+        "sha512": "18496c6d4f46ed04fdc57869520d7358699fb40ffb8da9a1fbbfb274a46e4f4391a564b7c0e48fd324f514e94865aee62098e954f8a912bb32bd5a81f5c7d314",
+        "dest-filename": "lint-QGNvZGVtaXJyb3IvbGludEBucG06Ni45LjU=-f859b4c82e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.8.tgz",
-        "sha512": "3e85ad66fa3b7355c57995a69b268ea761b45d56ce9e6f9f273be086a18092d056ddcb9fc09516bd209c346d29a5788110cd39999bba46132d5cfbf68699658a",
-        "dest-filename": "search-QGNvZGVtaXJyb3Ivc2VhcmNoQG5wbTo2LjUuOA==-1389fa4e05.tgz",
+        "url": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+        "sha512": "92816e357703bf2ca8b567203a7646998ecb66a10e5d969ac43fe3ea7d7c4c22f1dbff4789e649e47ea1b3583c162471043d0335fb349d79f5ee0f3bd9199877",
+        "dest-filename": "search-QGNvZGVtaXJyb3Ivc2VhcmNoQG5wbTo2LjYuMA==-2947341cf0.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.4.tgz",
-        "sha512": "f32ef1a86fe1a41e77976e422288adf7f9e0c5d7e81be7f1f95dd21c1ae29e784eb4bbca1d1c80249b87ce45ab4786175cb5fc79706c7a38000311d439d5b5cb",
-        "dest-filename": "state-QGNvZGVtaXJyb3Ivc3RhdGVAbnBtOjYuNS40-0e1b073282.tgz",
+        "url": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+        "sha512": "f50ccd0e01381180e70077eb4e547697088f72288eca62edc0a2bef321d0cc273b1978403fdc5d11b109172d88581d63f5419497d06c80c993a3f226034d93ec",
+        "dest-filename": "state-QGNvZGVtaXJyb3Ivc3RhdGVAbnBtOjYuNy4x-71493cc206.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@codemirror/view/-/view-6.35.0.tgz",
-        "sha512": "234b58cbadeae5791a5ac27c411bf987abdeb3b92fb6b0568c17277ff6f3a2114941ce5cd786b501045d13c4293c5f5e329e4cab614c9b9f530a3d600df13b93",
-        "dest-filename": "view-QGNvZGVtaXJyb3Ivdmlld0BucG06Ni4zNS4w-edf9cb81cf.tgz",
+        "url": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+        "sha512": "115ba719260dd70cf5a7be56635b375e0eedde2f18a25d241991a2ccd757f4150580c1482d855ef3fbba115a68ec57f93f06d9b882dbe1002aec86682b320440",
+        "dest-filename": "view-QGNvZGVtaXJyb3Ivdmlld0BucG06Ni40My42-be058e8652.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -4801,9 +4612,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@craftzdog/react-native-buffer/-/react-native-buffer-6.1.0.tgz",
-        "sha512": "9495dd8d9edf4e594b6f30ebc20fc5ac92e3439b0170083072a80007a38fa574c77427a71211d96e54297e604b2deeff4bb9b4c8a5cbde43778e9c0e124a631a",
-        "dest-filename": "react-native-buffer-QGNyYWZ0emRvZy9yZWFjdC1uYXRpdmUtYnVmZmVyQG5wbTo2LjEuMA==-78ab302974.tgz",
+        "url": "https://registry.npmjs.org/@craftzdog/react-native-buffer/-/react-native-buffer-6.1.2.tgz",
+        "sha512": "295d478ad374e451cb2c31bb65bff27ed0ec6be98a05807314c4343cc95dbd489cababd63ad02fcfd9836afb7b173a3387e58da8e444fb2143924756cac67f48",
+        "dest-filename": "react-native-buffer-QGNyYWZ0emRvZy9yZWFjdC1uYXRpdmUtYnVmZmVyQG5wbTo2LjEuMg==-c424beec79.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -4822,9 +4633,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@crowdin/cli/-/cli-4.14.1.tgz",
-        "sha512": "90f8575b80b0f1f7884e0375ca61fd50f49c2a8163e48c082f73db292785fd48505bd8e356c8e51953b958cd10632e6465825643ee1ef357225c5af9bf27e5a9",
-        "dest-filename": "cli-QGNyb3dkaW4vY2xpQG5wbTo0LjE0LjE=-ea45a7e6c7.tgz",
+        "url": "https://registry.npmjs.org/@crowdin/cli/-/cli-4.14.4.tgz",
+        "sha512": "03aba6c6d24417d5b80f8ca64914ef14dea1accbbf2daad15a59a389568d9def5e75a59a003058f1dc66275b34da715dc05c3464c97d3281a45580f248bd773b",
+        "dest-filename": "cli-QGNyb3dkaW4vY2xpQG5wbTo0LjE0LjQ=-b4fb2620b6.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5508,13 +5319,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
-        "sha512": "d1ca783ec590ffd6afa9354c0ad67e1a2ae2908037ea292f8ed1f0794e3f8fcc8bb6039b234f8950f858152720c25b5ebde181d6bb770a6f1484dd385dac838a",
-        "dest-filename": "schema-utils-QGRldmVsYXIvc2NoZW1hLXV0aWxzQG5wbToyLjYuNQ==-a219d60afc.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
         "sha512": "c2ce7b02276c0ef4442ab64a61f7d775d364c9a175e221cd1e6f15427647eadf7d13c81cce334dd06a6f7069f2d22982f34c90d2d1f3d715542a4fca150494c8",
         "dest-filename": "json-ext-QGRpc2NvdmVyeWpzL2pzb24tZXh0QG5wbTowLjUuNg==-61f84f6098.tgz",
@@ -5543,16 +5347,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.9.2.tgz",
-        "sha512": "18400d762fd280447e2fb25aa6cdb96221a297f0140e71451da0863c16ee9ddc685ad0a4036966cbbfed1668040f8cb586d032e8e8b8c2424441d1acb27c3d30",
-        "dest-filename": "babel-QGRvY3VzYXVydXMvYmFiZWxAbnBtOjMuOS4y-ff1806ee58.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
+        "sha512": "0d9cc53b52b7bff1a812dd5fc750e26071787a7f8fba1b507f50244096b9ceedc2a1e292a6be5ca50454973de3af49b8e30cb39925eef5b5697e2afe378fbc6e",
+        "dest-filename": "babel-QGRvY3VzYXVydXMvYmFiZWxAbnBtOjMuMTAuMQ==-50c7c3e02c.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.9.2.tgz",
-        "sha512": "64e562e866204dcb19714ce36e5a73937c07d45c9ad953697798ed1e808215c265310d4461765eb5f0274472dcca215e04005a23596d4d86ce06d1ff81a84654",
-        "dest-filename": "bundler-QGRvY3VzYXVydXMvYnVuZGxlckBucG06My45LjI=-767c355430.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
+        "sha512": "1c8a903ef6ea9e74117b836c05dd7bef82916ab8d7a92eb01ec5842edcae4acd6009fbe2c493b68d4187fce101b6bd46bf3a70fb37b90a318cbd227c504d4a53",
+        "dest-filename": "bundler-QGRvY3VzYXVydXMvYnVuZGxlckBucG06My4xMC4x-bb0401a1a2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5564,9 +5368,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/core/-/core-3.9.2.tgz",
-        "sha512": "1db8f029e0bea4750505f2cc373b928ea144ff9f3eacb54a98e53797142ba6cc4b04e1a8b18728fd0d0676e05bd3f8c43118b212a8cd4ffd35ad174e316ab9a7",
-        "dest-filename": "core-QGRvY3VzYXVydXMvY29yZUBucG06My45LjI=-3d6e121964.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
+        "sha512": "de97f67d75f0d1e564f169c2dd3e0b2228110eea5ca6f9e0a4aa3d572ee6632061b9d75cd2494352e64021fccca0aeb3d39a5d964e84142fef0525f8dfed4ee7",
+        "dest-filename": "core-QGRvY3VzYXVydXMvY29yZUBucG06My4xMC4x-097162b18d.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5578,9 +5382,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.9.2.tgz",
-        "sha512": "f2004aba9f78686b6d45db8006c8fb6e93c54d7ee46f0bbec61dcaf4d3021792b86d606a4c5616f9110a1c5ea20550c7449e20ad97483dbbe488777f5cd29131",
-        "dest-filename": "cssnano-preset-QGRvY3VzYXVydXMvY3NzbmFuby1wcmVzZXRAbnBtOjMuOS4y-21b9b78704.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
+        "sha512": "78d7c719c4ca092abac6671abc0917dd145c947684db144230f6ab9435cb75754fd35fdad9efe3297323ff450b9cb15048dc30b88eb62f419ef09fa766c47b51",
+        "dest-filename": "cssnano-preset-QGRvY3VzYXVydXMvY3NzbmFuby1wcmVzZXRAbnBtOjMuMTAuMQ==-caeb902202.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5592,9 +5396,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.9.2.tgz",
-        "sha512": "fd2542739ec1c8047319253ad1ce74accc90941b8c2090a372c26592987163a074195e141f7b5c035f7de0df1f15f6c9f645f78c805eff18375cfe6a06d1836c",
-        "dest-filename": "logger-QGRvY3VzYXVydXMvbG9nZ2VyQG5wbTozLjkuMg==-4d7b1bccc9.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
+        "sha512": "a0f8cd1677c9b110a478f563906af1586ab832f24a4504f4afd8ce3f479105367b5abf4501bcdd3ff1a3b342364ace984643e8120ca0286d75d8e904eac92f27",
+        "dest-filename": "logger-QGRvY3VzYXVydXMvbG9nZ2VyQG5wbTozLjEwLjE=-84adf6f031.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5606,9 +5410,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.9.2.tgz",
-        "sha512": "c226281b017d81d77aadebfadb10d4f0000cf09b8b23f865c0eb42ccc99872ca4493379c2ab3fc27c5fe2a96274e500205452d5cd2694a80b01562612d17afcd",
-        "dest-filename": "mdx-loader-QGRvY3VzYXVydXMvbWR4LWxvYWRlckBucG06My45LjI=-0077773014.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
+        "sha512": "19199e6ffc10fa25d1ac5c1c1c17e0421ac9c46125802b284d66580e171c8ec6559ded69f0c2bf129415225a17b6dcfbe9309eefc90a0f90041bd9f5c5cd68c5",
+        "dest-filename": "mdx-loader-QGRvY3VzYXVydXMvbWR4LWxvYWRlckBucG06My4xMC4x-71db855425.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5683,9 +5487,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.9.2.tgz",
-        "sha512": "58b87bca68035e31bca0fa0cfd3e3fcd43fb29c4ae1584590144e5f2f47a5736247dcd7c181338c4b85c4fe00a3b0ba7ea4062bd829425ffaf96a609926f911f",
-        "dest-filename": "plugin-sitemap-QGRvY3VzYXVydXMvcGx1Z2luLXNpdGVtYXBAbnBtOjMuOS4y-adba37c28f.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
+        "sha512": "0b6e8c6e69aa81d8e40ead61b5a677683ecbcc40ca1565dfa72429b7410e51386eab99d5efbcc369e755db4c87715a3da7eddecbd699e296c70340f741c653ce",
+        "dest-filename": "plugin-sitemap-QGRvY3VzYXVydXMvcGx1Z2luLXNpdGVtYXBAbnBtOjMuMTAuMQ==-6421d4ea3e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5753,9 +5557,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/types/-/types-3.9.2.tgz",
-        "sha512": "531d4950db3083e11f50499a8c98f2848a2129c7a2b58ff2ce3454a6ed3859782f573f9f6e1542d29f91d0986f12ee32b70f33200cacda1adda503c11d121af1",
-        "dest-filename": "types-QGRvY3VzYXVydXMvdHlwZXNAbnBtOjMuOS4y-bc91d05a20.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
+        "sha512": "5d830af24d6ccc3085330d95f97c9e9f483b29e7b5b0fdddb459e5eef9069193a478027fa0f0d03cbf22cf81c128ea3f73053c41e57aa2756332ab4ffad173b3",
+        "dest-filename": "types-QGRvY3VzYXVydXMvdHlwZXNAbnBtOjMuMTAuMQ==-0c4c641e18.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5767,9 +5571,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.9.2.tgz",
-        "sha512": "239dd40b541cb6bb80e9258bbdb8db842a40c3bf97ecf78fa1ee6961cc133845c3fcfc5e3fc2e71020214c71f05826e5c945f96cc8b840b464c6fc99f884fc03",
-        "dest-filename": "utils-common-QGRvY3VzYXVydXMvdXRpbHMtY29tbW9uQG5wbTozLjkuMg==-77e01da05e.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
+        "sha512": "e66152804003b67171147ed12f0d36400e4ca54e495540a3d0c3de22f8bf685e058b8e6d41122e4f05e85c3a89fb555f409b98246cf7488eb7c261b3e07bd7cc",
+        "dest-filename": "utils-common-QGRvY3VzYXVydXMvdXRpbHMtY29tbW9uQG5wbTozLjEwLjE=-db7a0aac5a.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5781,9 +5585,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.9.2.tgz",
-        "sha512": "97bca4dd7e559cd9804dbc228c991ec5d86e94db1068d0f0a1a822c2e8d7a3115b58b7311d0a8d43e73f200973adf30c39f6bff3148167b2842837ac13fd89ec",
-        "dest-filename": "utils-validation-QGRvY3VzYXVydXMvdXRpbHMtdmFsaWRhdGlvbkBucG06My45LjI=-d8a853d7e7.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
+        "sha512": "711bf55faf63c1a5afe3bc1a825965819556cde0452e1979dd74ff5c40fff3705ead50530b91533fc59371597c67ab1939e8034b08adbbfc290923c20ce4fa96",
+        "dest-filename": "utils-validation-QGRvY3VzYXVydXMvdXRpbHMtdmFsaWRhdGlvbkBucG06My4xMC4x-e1c69deb39.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5795,9 +5599,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.9.2.tgz",
-        "sha512": "941481891aee16eac5297af91dbb25dad8661b07803e675d845de36fdf54e043030392fe7b9635ac090e4b4ecdbebba9ec750c043ac2578e6679ac599eddbc9d",
-        "dest-filename": "utils-QGRvY3VzYXVydXMvdXRpbHNAbnBtOjMuOS4y-bb4f24acd4.tgz",
+        "url": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
+        "sha512": "de88de26bcbdc4161d24eeaaa32cb3a9e245489055c769978720f349d8f02f6f9444540c7fe876e601b7f22b301889a270ad042e34ddd442f6c7393c85fdd03f",
+        "dest-filename": "utils-QGRvY3VzYXVydXMvdXRpbHNAbnBtOjMuMTAuMQ==-b8a2a7c1f5.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5809,23 +5613,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.2.4.tgz",
-        "sha512": "97291f6374c9451585793c5c70429d7f523a04b9763e5c3cd47d1b6e9e0573988473aedfa0309ae698c94142d5828d3017e0e58bbe5fdf155c75bffaec5159fe",
-        "dest-filename": "asar-QGVsZWN0cm9uL2FzYXJAbnBtOjMuMi40-22cdef5ad3.tgz",
+        "url": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+        "sha512": "8b8feb34f452f38b74bd245ad87a2b7ab1915d6c85e2f4e17c77acc347667161e9f9cb292bbe3751a9c0d2cb80e50e72f24cd8db2e982abbdb2149faf4108088",
+        "dest-filename": "asar-QGVsZWN0cm9uL2FzYXJAbnBtOjMuNC4x-c41c6b0a5e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/get/-/get-2.0.2.tgz",
-        "sha512": "7856551684576f718519dec093b5b8fba8c197dc01b6267801a60eb1ef7b7a3ea62a3e6d9323b47549d40a1b35221259b71d4110da38fe9e165135e98babd3fa",
-        "dest-filename": "get-QGVsZWN0cm9uL2dldEBucG06Mi4wLjI=-c92cf51c21.tgz",
+        "url": "https://registry.npmjs.org/@electron/fuses/-/fuses-1.8.0.tgz",
+        "sha512": "cf1d0422aefc5a563f9416f5b97973899983648e2e6dc09720c278b868d7cd95b49d2d7d4e348f7973c08f3cd398a425254666d126e66613ca3fbb6e4354ac13",
+        "dest-filename": "fuses-QGVsZWN0cm9uL2Z1c2VzQG5wbToxLjguMA==-fcd6cc79c0.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.2.1.tgz",
-        "sha512": "68bf9b14c224a51d1c9a68f9660cb42cc284a60cb8dff870e7369d100ae09803165a529ce5bbb016f153f46fe8fd8264bd70099b9ab78ae4ee2da89a5d6dfdb2",
-        "dest-filename": "notarize-QGVsZWN0cm9uL25vdGFyaXplQG5wbToyLjIuMQ==-6d5bb78a0b.tgz",
+        "url": "https://registry.npmjs.org/@electron/get/-/get-3.1.0.tgz",
+        "sha512": "17e9ca734c56fa455b051845cda3203f2dcac26b8d4d85f57f1ebe171c684a7360c185fa2c3ec02814d6914d0c43a201a1eeddcf4ebd08d911ebbdec3c082409",
+        "dest-filename": "get-QGVsZWN0cm9uL2dldEBucG06My4xLjA=-0645d6da26.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
+        "sha512": "a63a01a6bbb529d12d704c419ee1c03f570073fe5f6a879dc348732642f7a38fc8269ec7345d7e7dbaddc53de0318457da825fbe703f5977824d5429618c7224",
+        "dest-filename": "get-QGVsZWN0cm9uL2dldEBucG06NS4wLjA=-b69a1874c8.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5837,16 +5648,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.0.5.tgz",
-        "sha512": "93d673510b5a992a307864035768c82e24481d4bbb958949ddce881268efd610b5eeb72513e79bf54f9fe9416538e113a342736351cd957cb860e942be5f8bc3",
-        "dest-filename": "osx-sign-QGVsZWN0cm9uL29zeC1zaWduQG5wbToxLjAuNQ==-b8df7c0979.tgz",
+        "url": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
+        "sha512": "299f26857bd6bf6ac812031b599e32df76c31f250a3179f1e0cd2c4f23cd2bfbdc07cd4899d798f4681dab2d1259b3038266eac90fa98607a387a57747642e4a",
+        "dest-filename": "osx-sign-QGVsZWN0cm9uL29zeC1zaWduQG5wbToxLjMuMw==-9a6ebae2fa.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.7.2.tgz",
-        "sha512": "d7dfca6c847f0c0c5bb0292268631721d3e730224b91c7fc02f1a776e26d581b3f081c220236356a90aa38b571ad783eaed5c50a781b5e105a9d68f12d4b7532",
-        "dest-filename": "rebuild-QGVsZWN0cm9uL3JlYnVpbGRAbnBtOjMuNy4y-0840b88f19.tgz",
+        "url": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.1.0.tgz",
+        "sha512": "185932fb525e3bc7e94aab590a1fb6c0544dfcc55b0219bbb5723633b040d4eb3bf4e47c2c4a3146d01b44fcb1be6296844305fe9d74acd2649203f5925235de",
+        "dest-filename": "rebuild-QGVsZWN0cm9uL3JlYnVpbGRAbnBtOjQuMS4w-4107db217e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5858,9 +5669,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@electron/universal/-/universal-1.5.1.tgz",
-        "sha512": "91b817c7211ab8f26241050d1b656051ec9f40d164ea1045d752123763cd23a6a05203e5e79a6fe1e4266aa1f34c0cdc841bea676b50b9155a3d2b467f49b11b",
-        "dest-filename": "universal-QGVsZWN0cm9uL3VuaXZlcnNhbEBucG06MS41LjE=-9e6cd5dbc0.tgz",
+        "url": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.3.tgz",
+        "sha512": "5a7f6c3d8215151165e479b030990044209feeba8afc4bab91f43fac9675e261cfde26138d94883925689c40278567805f0b70ef339e90646573ac93b59d2dfa",
+        "dest-filename": "universal-QGVsZWN0cm9uL3VuaXZlcnNhbEBucG06Mi4wLjM=-8c1c9bb0b3.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5977,9 +5788,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-        "sha512": "199301f9ad2638c66ce0ca436e3f11269e1cc3ec35595e4d603eb1ce0bf3509e449368deaf07ced9e003c88e84c43494103fb55fc68c6de81a86c262fbc9a0a7",
-        "dest-filename": "aix-ppc64-QGVzYnVpbGQvYWl4LXBwYzY0QG5wbTowLjI3LjI=-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.5.tgz",
+        "sha512": "9c6b05ff80bbbb3523f8d8ffe09f99b746d843a6f3df73e1cfc2dbd8df3432d8b51e319c95325d5d9fbd00f0b890bbce35b8f1375cdfbd835df0511c6c12bf31",
+        "dest-filename": "aix-ppc64-QGVzYnVpbGQvYWl4LXBwYzY0QG5wbTowLjI3LjU=-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -5991,9 +5802,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-        "sha512": "0d5348f2394f6bb5236ebd728d4d8f7d4491b405193c6f48d51c16e05e31141d489a2bb6a27d000e223f737b5df8a983b5528d6e2fa77df18340c7dc20c93020",
-        "dest-filename": "android-arm-QGVzYnVpbGQvYW5kcm9pZC1hcm1AbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.5.tgz",
+        "sha512": "0afefcd6377445f8ffa5aa0daee975febe06d072efb8529887b0bdb876763e5f185ecb73bc2cb279610d4c547da859d1ccd3028d79acba566ebe8b03835d0ca2",
+        "dest-filename": "android-arm-QGVzYnVpbGQvYW5kcm9pZC1hcm1AbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6005,9 +5816,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-        "sha512": "a6fcfc659ee8b7f441a617fc7efeb496399aa3274f535d95b971c89ad02cd1784b2f0f845c18b604b7b7398481b25478aebc87bf0796e609a4285c13885cba28",
-        "dest-filename": "android-arm64-QGVzYnVpbGQvYW5kcm9pZC1hcm02NEBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.5.tgz",
+        "sha512": "39e821abe5c5821d6950677560ab380c3a31cf1928524be4a3e4ff2152b096084a2efbe36c6141dde93c5440c198dbea870b8bd02412ddc131773a6653222b80",
+        "dest-filename": "android-arm64-QGVzYnVpbGQvYW5kcm9pZC1hcm02NEBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6019,9 +5830,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-        "sha512": "cfc0279380728784c924e878c29cfc836bc3cbbe7314bd13959964524130617b8f4a05fccb37a9e7dea7ea64fbf74e6403db8766c7ffa3638966e6e5da5dccec",
-        "dest-filename": "android-x64-QGVzYnVpbGQvYW5kcm9pZC14NjRAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.5.tgz",
+        "sha512": "9d00fb96ca5bcdeae59ad34ec583050069a1c60ce7f19ee6f63805921ea4a648ec02165e7b5c3cb495b76655be37d89178fcf4a0f503ad8ad789d08f488983d1",
+        "dest-filename": "android-x64-QGVzYnVpbGQvYW5kcm9pZC14NjRAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6033,9 +5844,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-        "sha512": "75abc20f665cf349f30d54705d37103ffdbc7e225b70ec2f76894bd2c3a23ac6f005aef691e826554d16ae1d4c62b6ee08bf7c3a6a7975585015644a47664096",
-        "dest-filename": "darwin-arm64-QGVzYnVpbGQvZGFyd2luLWFybTY0QG5wbTowLjI3LjI=-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.5.tgz",
+        "sha512": "23e61afcc802eabafca115864431770570df3fc2b5055520807a8de9523695464b7438b520cd6fd9ccb47b79423db3fea5570add3bfc7205211ec7b591a35967",
+        "dest-filename": "darwin-arm64-QGVzYnVpbGQvZGFyd2luLWFybTY0QG5wbTowLjI3LjU=-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6047,9 +5858,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-        "sha512": "671b628ce9a54020561b06d59b0385fd40b3b8621b524a81d5f69045fe5a9109b1449d6e8eeb16b1bdc255f93ff6264aaf62f948c539c0f062d5459bbcbf9540",
-        "dest-filename": "darwin-x64-QGVzYnVpbGQvZGFyd2luLXg2NEBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.5.tgz",
+        "sha512": "3028d052d0bcc16267fe920f33bbd068eebd0458303c3d63ae211dab04c22b35a31a090c6dc83e3391f3ace84f86e61ed402635e51e60f5e362907fe8e7623f0",
+        "dest-filename": "darwin-x64-QGVzYnVpbGQvZGFyd2luLXg2NEBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6061,9 +5872,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-        "sha512": "952ffd08dfab82a43d733a20c6531c04c19dfa5f10dcd8f5305430059272a04288e745c6c70bb3ce761dc1c6afea5a4e1afe41a9a657aaf052881fe4279a29fa",
-        "dest-filename": "freebsd-arm64-QGVzYnVpbGQvZnJlZWJzZC1hcm02NEBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.5.tgz",
+        "sha512": "5fac554be828487d147a56179ee7f81872f0a4e75cf2b80aff36a2f9d2b304c9e7730ec14d0230aae3a8744ec42af63651551eb52ab201fc990b50fea2a2d0b6",
+        "dest-filename": "freebsd-arm64-QGVzYnVpbGQvZnJlZWJzZC1hcm02NEBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6075,9 +5886,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-        "sha512": "b407eab4d61be1880f9c994416ee1cdb5d8762341648eff0fe1fe541a04aed16f01889013ae34a408f6da96cf1ed6b69edb4cf6860ba309bd623ad3c3f7c1760",
-        "dest-filename": "freebsd-x64-QGVzYnVpbGQvZnJlZWJzZC14NjRAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.5.tgz",
+        "sha512": "db7dd7d451a8ddaf31d5e90b07a5d3ebd2df67cdefab3fbdcf74d211009361f30d63cf3403dee7afcd4a6cf700325f6b98e169d75c0ed1d3fe781d7c294fd472",
+        "dest-filename": "freebsd-x64-QGVzYnVpbGQvZnJlZWJzZC14NjRAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6089,9 +5900,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-        "sha512": "bd67eae0668830ff4021ee328f56545b5f110e1c7a10f40a8f07bb9fc05b21e705b42406e027c719a1ee87b7dd7eafb2dcb200daf192fe8f590465712038bd87",
-        "dest-filename": "linux-arm-QGVzYnVpbGQvbGludXgtYXJtQG5wbTowLjI3LjI=-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.5.tgz",
+        "sha512": "d30915ad81c6e2c74208dfdb73043bc9831700291a1dcdd415e6843b04955ba7b947270c6a0798005bfe252d9b28bc07c9e29552fb68547fb9fd11ead1f81e17",
+        "dest-filename": "linux-arm-QGVzYnVpbGQvbGludXgtYXJtQG5wbTowLjI3LjU=-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6103,9 +5914,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-        "sha512": "858c4df29afae8db020a2445907500b31ca534e70041ac524a41cc323729c74b22d77b752c71698712595221b0a230756bf1dde4e88f22a0dd5ce3626ba6e14f",
-        "dest-filename": "linux-arm64-QGVzYnVpbGQvbGludXgtYXJtNjRAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.5.tgz",
+        "sha512": "7ae2a48a5b0d3afef1fccd4d2acc79ce7ca9adba6c4452334d5ea55b38aa25c87bc9661ac9f2ed6730f10d397e2d240325802377d4d56ff2ade54288ae3d9ee0",
+        "dest-filename": "linux-arm64-QGVzYnVpbGQvbGludXgtYXJtNjRAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6117,9 +5928,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-        "sha512": "309b7905145249c3c3c06da12de95884000a87d8a68c72b9f8d13fb6f9d12db22a5166bed04f4de1634c8e6a7f9175cf1d91aa3cbc60830561cfb40ff024d1f3",
-        "dest-filename": "linux-ia32-QGVzYnVpbGQvbGludXgtaWEzMkBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.5.tgz",
+        "sha512": "8554505f8f8fdcc4b7e8dc4ecb6e2ffc276c8a6cbfe4761e3f0fad98faa734dd5fc55d1b3eb15647a4ccab05cfc284ccd95cdb900fb895b1d650a0dde590c0ff",
+        "dest-filename": "linux-ia32-QGVzYnVpbGQvbGludXgtaWEzMkBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6131,9 +5942,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-        "sha512": "96e8321756ad9c04f8eb768ee8a3ec8550892b9360467538c9bdc552e9b2573f9c1af65ba27b4183378614ed6717e74fb9e1c3dfaedad995ded4db549008ceb6",
-        "dest-filename": "linux-loong64-QGVzYnVpbGQvbGludXgtbG9vbmc2NEBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.5.tgz",
+        "sha512": "98aaaa46e38f00b23c9c3ce13819884b420dbd938e1461a0e67d68b06217031f287abb1c7846ca778b750023531ccdec2415c614094482a33eb2fce33e8b7e65",
+        "dest-filename": "linux-loong64-QGVzYnVpbGQvbGludXgtbG9vbmc2NEBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6145,9 +5956,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-        "sha512": "9e53f623a02b1017b0bc9da08ebae4112119901e66228693b30baa34546ffd661df804ed5297bd634f519c9be0bdd6a0ee17b439680465686f892d4e4ce2a2c7",
-        "dest-filename": "linux-mips64el-QGVzYnVpbGQvbGludXgtbWlwczY0ZWxAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.5.tgz",
+        "sha512": "104fd05c7f48c9a023d6a7ae215e7efc66640538a98063bbf3615fed49b7bcf4bd72f2e12497804f2e068318a4cf68a7678e8a0726a6327e86aadab256385e9c",
+        "dest-filename": "linux-mips64el-QGVzYnVpbGQvbGludXgtbWlwczY0ZWxAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6159,9 +5970,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-        "sha512": "0bdda09e97b2eed51038daa0d67e9d2956f1defa612ad4c725a346d8e93d946c1b66297a0eb7f279c32ca7d0ab99719026667b8a2557bef647e8c97984be9775",
-        "dest-filename": "linux-ppc64-QGVzYnVpbGQvbGludXgtcHBjNjRAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.5.tgz",
+        "sha512": "d15da2175446c417f56fbfc18eeac0e637e497b3edc928e89b5afac4e2b6abd296c3f5c2a4076d07a28d30efbdc71ebdc987d209147d144d13c8a7c703679033",
+        "dest-filename": "linux-ppc64-QGVzYnVpbGQvbGludXgtcHBjNjRAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6173,9 +5984,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-        "sha512": "07904e9a88cdb54c8df005e52b4409caf8c46645b0cbf14abda9244c30b3897f79028c0b64a47a6820e11bb2de17bb8c097109ab06bc05e8f3e4b4cf626f00bc",
-        "dest-filename": "linux-riscv64-QGVzYnVpbGQvbGludXgtcmlzY3Y2NEBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.5.tgz",
+        "sha512": "ad8c53841c7a1bd1cdead14dbaf07fbf291e2e2e150ec9b9844e69570cea6c08d9100450ad6bb79e86527db1273d9fc24573f7dbbd46c8593fe3dba9d96d7dd2",
+        "dest-filename": "linux-riscv64-QGVzYnVpbGQvbGludXgtcmlzY3Y2NEBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6187,9 +5998,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-        "sha512": "a786e6f7ec2c3f0ba9e59f1fe04a5f37adea35a810e3b51adb39daa861fa6ea2e5989e1bc7ded8f4976ac60199e98f315538b1527124a0a4877294650e736be7",
-        "dest-filename": "linux-s390x-QGVzYnVpbGQvbGludXgtczM5MHhAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.5.tgz",
+        "sha512": "b843f6abfe2a81df20a0451ce1021d53fd4fd8d984b59ff35f9bb73a92e508684922e048bf4b34c2bed30769c1adddff0395c87449244b964b17450bbaf69a61",
+        "dest-filename": "linux-s390x-QGVzYnVpbGQvbGludXgtczM5MHhAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6201,9 +6012,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-        "sha512": "bb0a764e2a7968f987f8d454c1371f2dbf96df65978e915e8d320e599170fefeff2a7a420ca1baeaee032dcbab4298984e263043d07b28e78c26f2c2bbf3af6c",
-        "dest-filename": "linux-x64-QGVzYnVpbGQvbGludXgteDY0QG5wbTowLjI3LjI=-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.5.tgz",
+        "sha512": "f86ab8ed6aaae8f2ce399b81cd5488236ffff72c8734a64bbb07f309e9aa7b1a8e4024b3d33cb43b6ea4233ca9f4430d30afa7674b451c166b09e554b8cb3f7b",
+        "dest-filename": "linux-x64-QGVzYnVpbGQvbGludXgteDY0QG5wbTowLjI3LjU=-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6215,9 +6026,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-        "sha512": "2a3e838819705eb3ec0910de46f18051bfcb36b0404ab7ea008a24fb10742f12bc087ab1674dfbbe2175dee81fb08a5e3c7f77997ef17c9a7dedcc83b9367773",
-        "dest-filename": "netbsd-arm64-QGVzYnVpbGQvbmV0YnNkLWFybTY0QG5wbTowLjI3LjI=-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.5.tgz",
+        "sha512": "dc5ff9106f151df37f23e5b970ed7f495d87f50ff9afbbdc1da6cc9c1aa11cada54d63a1dc5f2f8b1373a3c96ac6b96606d6551695bca662131e7ab9e3e4eae2",
+        "dest-filename": "netbsd-arm64-QGVzYnVpbGQvbmV0YnNkLWFybTY0QG5wbTowLjI3LjU=-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6229,9 +6040,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-        "sha512": "1f018367454b54163763e370d097b1672f68fe75005aaf4c955edc6a1a5a5ca5ba4cecdf567a37cb7fccf066bcbbc62bec695d2cea2fdbbc620a7a9165fd2d08",
-        "dest-filename": "netbsd-x64-QGVzYnVpbGQvbmV0YnNkLXg2NEBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.5.tgz",
+        "sha512": "dbcb7e4a3dc23cdf2f90c3a5668b4e983822950c15bf159997b6fcaf1a67ef74edfe00a7beb1f1414327838baede2b5d16faed6daff59c77a3bf1ab3f3180430",
+        "dest-filename": "netbsd-x64-QGVzYnVpbGQvbmV0YnNkLXg2NEBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6243,9 +6054,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-        "sha512": "0cd2071f604f439e79d40ee84870f408a6f0200fcec7bfbbf3f01691b4b94284736aa95ebf6b856b27d2c6aebc124a2707e20a8e2bb1045a15f04489cbc6ce1c",
-        "dest-filename": "openbsd-arm64-QGVzYnVpbGQvb3BlbmJzZC1hcm02NEBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.5.tgz",
+        "sha512": "0e8cff84ab62b95022f6132c04ca7004036121973c976dfc5363a7928deddb1529f31b4cd1929d0d81cc9e6fea3c556d858f0ab719176a873098c87a56897330",
+        "dest-filename": "openbsd-arm64-QGVzYnVpbGQvb3BlbmJzZC1hcm02NEBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6257,9 +6068,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-        "sha512": "fe2b7bc3d35befed0a148ce36a5349551e5b3b303d55acbec883cb5477c84181bf8fe8fd5531fce1a341f04c4628f5380337da12f37dfd5e0757e17ebe8f0e12",
-        "dest-filename": "openbsd-x64-QGVzYnVpbGQvb3BlbmJzZC14NjRAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.5.tgz",
+        "sha512": "59f19569ad68cf903bf9914f9044486c884a4f8a25bc6975b72cd345a079ca86512ea0b42b068ef7915e66d39d423fe82a48d6e7b29c545f78e26eb6ff4198b4",
+        "dest-filename": "openbsd-x64-QGVzYnVpbGQvb3BlbmJzZC14NjRAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6271,9 +6082,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-        "sha512": "2d105b0a6894e752177de5e4e7d72cb97fda49a4e8786ef0e3c9ccc00eb4e3d638278f956d600b02e5dcb3ea9c0f4e2b1c3b9209244a76663adecaee0d2e6a6a",
-        "dest-filename": "openharmony-arm64-QGVzYnVpbGQvb3Blbmhhcm1vbnktYXJtNjRAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.5.tgz",
+        "sha512": "5e1f9546e87a38c877b89d099028c8e7b97e0d57bb55118163299e9fcac53e74d58004c1c00ea7993a313363b04e54afae75a93ca92b4148fddfe2bd86e602e8",
+        "dest-filename": "openharmony-arm64-QGVzYnVpbGQvb3Blbmhhcm1vbnktYXJtNjRAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6285,9 +6096,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-        "sha512": "90cb71d72a891d39aa6aa1cf0332820240da2ac7df99790f1d38527d1c191b2baac88781bdfd3c292b185e5f9a6dfe470c03cc2483e76c17d7bcfd990b64df1e",
-        "dest-filename": "sunos-x64-QGVzYnVpbGQvc3Vub3MteDY0QG5wbTowLjI3LjI=-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.5.tgz",
+        "sha512": "682d60a499246940031ee01d41fb954e7a955132eaa9436102f1301f055672755566f3650cf180d14bde66c7d7249f53ea4f4fa387878b7734da06ddc0ede0eb",
+        "dest-filename": "sunos-x64-QGVzYnVpbGQvc3Vub3MteDY0QG5wbTowLjI3LjU=-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6299,9 +6110,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-        "sha512": "61a7fbf0efc1dca921fa728005417ef9bbc9bf9223a32f40375c30f74e2b3976452d655ce4e2ce7cbe7a5be0bc17dc67e494196b7517ea6f8892d26721bd498e",
-        "dest-filename": "win32-arm64-QGVzYnVpbGQvd2luMzItYXJtNjRAbnBtOjAuMjcuMg==-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.5.tgz",
+        "sha512": "d14371d9a6af5747e4e94a597305c52f3b40dabfe4f634d46bb396ed201e6b555852192e83df4c5b5b997971273e7e7e70739dd27f26c906b2e939459c1474ef",
+        "dest-filename": "win32-arm64-QGVzYnVpbGQvd2luMzItYXJtNjRAbnBtOjAuMjcuNQ==-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6313,9 +6124,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-        "sha512": "22ec2cd24c68e32bac93bb30ef45dad84da29995391e88b1cf17c609dc7005d8620e0b7dbd7f55502061a9cc18effba1fffefc03584c92444e309abd976ee82d",
-        "dest-filename": "win32-ia32-QGVzYnVpbGQvd2luMzItaWEzMkBucG06MC4yNy4y-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.5.tgz",
+        "sha512": "e67949dc07895824d2cd1ec012a5634ff7da5b2a8a53cea40a2d652e6c55aa6351fa3e07ad8767b3e7931a34bfbe6af30887bc8a719072451a76f4b4f8990a75",
+        "dest-filename": "win32-ia32-QGVzYnVpbGQvd2luMzItaWEzMkBucG06MC4yNy41-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6327,9 +6138,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-        "sha512": "b11754d7c99c29fec5f98821788ff319fe5a9596ad3144ca8ff8cd4ba97be387fdbb7585bb8bfbb7071423dbeee2692717863d68395b94889ed0833ee71c5aa9",
-        "dest-filename": "win32-x64-QGVzYnVpbGQvd2luMzIteDY0QG5wbTowLjI3LjI=-10.tgz",
+        "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.5.tgz",
+        "sha512": "3d6ca9411f9de052df92104857efe41ec5042c09cca71d5b46fbec9f7a7efec00445b9c2cc5aed0d11b65f0e67fb6ccfc412b6fa268ffaf7adb119784e2ed680",
+        "dest-filename": "win32-x64-QGVzYnVpbGQvd2luMzIteDY0QG5wbTowLjI3LjU=-10.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6348,9 +6159,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+        "sha512": "a61ad898d898a6947bce714476a81f5875d1e8d0a46442bb8705831d95238adff6fd4d2be97be40e5d12627a0ce751eaec584219d2c34facf1082398d617b1b1",
+        "dest-filename": "eslint-utils-QGVzbGludC1jb21tdW5pdHkvZXNsaW50LXV0aWxzQG5wbTo0LjkuMQ==-863b546786.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
         "sha512": "9b80d537d66ab246682d4e4695665a7700e7628def004c9d8946b207dc2274297d7df5b1d88bcf9e9ea7de89f9ac99b38894b0f41bfe6770a10d574cc17098f1",
         "dest-filename": "regexpp-QGVzbGludC1jb21tdW5pdHkvcmVnZXhwcEBucG06NC4xMS4x-934b6d3588.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+        "sha512": "12b8924e5b79382f7fed25e445208085f4b1c684948019b7dce1fe224c1b769828aac4ac520ef2dee87e208088fd08380415abdd4da2dfd4699b271bc4cab87b",
+        "dest-filename": "regexpp-QGVzbGludC1jb21tdW5pdHkvcmVnZXhwcEBucG06NC4xMi4y-049b280fdd.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6362,23 +6187,65 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
-        "sha512": "3d688eccb21402337fc392b5ecfa05e27eac281c3482a2c73e1cb09981cfe2dd5515041561e6f5c96b09c2731510c977b541cc13b5ff4893d92e6b46ed7043c5",
-        "dest-filename": "regexpp-QGVzbGludC1jb21tdW5pdHkvcmVnZXhwcEBucG06NC44LjE=-f8c99ca48d.tgz",
+        "url": "https://registry.npmjs.org/@eslint/compat/-/compat-2.1.0.tgz",
+        "sha512": "2e06920b2984a70eed179df1bc3c3d48db2b68f6f52011f1a5d00120e334856f140253fcce7ae362dbb17d1e7c1522772fd061c03f8568f44542966af38361ea",
+        "dest-filename": "compat-QGVzbGludC9jb21wYXRAbnBtOjIuMS4w-e868afc209.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-        "sha512": "dbaf59dfd312eb0549b6ca14975d0beb459d92125574f1b6e10e1e6531f79e717a969bd24a110adf04230d7f494560143ef3e1ec23a8b8fa54f48aea69916fb5",
-        "dest-filename": "eslintrc-QGVzbGludC9lc2xpbnRyY0BucG06Mi4xLjQ=-7a3b14f4b4.tgz",
+        "url": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+        "sha512": "9c99762864e5adff468cb8a6808aeef95fe6ce048ad000420d046fc70e418d444bed67c7e6ea169a2cdb1fb401e8c9a730177c7080bdb9c7969deccbd556565b",
+        "dest-filename": "config-array-QGVzbGludC9jb25maWctYXJyYXlAbnBtOjAuMjEuMg==-148477ba99.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-        "sha512": "77dcda31149320a0cb85cb731f5d8cb57bc929249485a1dc8d5fb667e18af84118ed72a93f9c91e31f8ddd301c1d372ef7ade722bf9331c09be03042617d73e9",
-        "dest-filename": "js-QGVzbGludC9qc0BucG06OC41Ny4x-7562b21be1.tgz",
+        "url": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+        "sha512": "801af137cf203887f747b8dae4af6c97035ac9571980ae923943919b6b81cd378811f79568884ea42b53a31dcfe91ee8da32c5c0b1532e70bb914fd119c60483",
+        "dest-filename": "config-helpers-QGVzbGludC9jb25maWctaGVscGVyc0BucG06MC40LjI=-3f2b4712d8.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+        "sha512": "c8bfec2eba66b43685122523d68b113f84c8d8c0f3d4075d24bfa367b292aaf06e962378c6a618e7821f74df2a0fc4e86ba8358a5a298757f140d9233b1aeba5",
+        "dest-filename": "core-QGVzbGludC9jb3JlQG5wbTowLjE3LjA=-f9a428cc65.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+        "sha512": "330704d4ff806780ba0d69698a7fce98e039e2698867ffb166e26241de12c81dbda00263377d145bdc2428da6d5b672da78704b2f8652d8fc2b10d6ea070e5a1",
+        "dest-filename": "core-QGVzbGludC9jb3JlQG5wbToxLjIuMQ==-e1f9f5534f.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+        "sha512": "e08949c745f4a9fb55b0de44fbfbc6ba34d1205b70b8b6cdb1551eed33bacd83c34753ba9c5c2fc2120a10a4ab97a7597219980484dacf12a85183a376d8e546",
+        "dest-filename": "eslintrc-QGVzbGludC9lc2xpbnRyY0BucG06My4zLjU=-edabb65693.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+        "sha512": "9c4ec3108721bed8854f0070e0b7dbbb9f4f1be902a1f863b0a6825b3c53a6de257d18d132a1bab8c073297b847325e1387a14a7dae2026eff69660685767d73",
+        "dest-filename": "js-QGVzbGludC9qc0BucG06OS4zOS40-0a7ab4c410.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+        "sha512": "56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738",
+        "dest-filename": "object-schema-QGVzbGludC9vYmplY3Qtc2NoZW1hQG5wbToyLjEuNw==-946ef5d623.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+        "sha512": "e37feab6b0d4a24afb2c9aa8176737f91227bbfb78cdfae961da120df632860e76af02d5e939cebdd1b87d79bb224481df012b91c9894bd88486356d3921238c",
+        "dest-filename": "plugin-kit-QGVzbGludC9wbHVnaW4ta2l0QG5wbTowLjQuMQ==-c5947d0ffe.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6411,9 +6278,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.22.tgz",
-        "sha512": "0531f61427338492df8f57297dc2abce12a7bd12d33b3b605b86d5968283a87f86dd94a88562d114d008cf9e97b5d8cfc416e2dbfa96846040925ee40689ff27",
-        "dest-filename": "cli-QGV4cG8vY2xpQG5wbTo1NC4wLjIy-c20c89f573.tgz",
+        "url": "https://registry.npmjs.org/@expo/cli/-/cli-54.0.25.tgz",
+        "sha512": "5a752a21bf2830186dc127c8a9d0870b371a0c8a4b35722d4557799a2baf5a2e063b4486a3cf4f4ac0246d527e2c981c698fafe6b6e03042c94bd23f0aa3ae94",
+        "dest-filename": "cli-QGV4cG8vY2xpQG5wbTo1NC4wLjI1-6fce61424f.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6432,6 +6299,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.5.tgz",
+        "sha512": "696437b1588d468416c3a4a8e00daa8560addb80ae1812ba32b447235006f95ebf350023219087692bdc5cada05caa668ac4614d251668a3c880b250141f8079",
+        "dest-filename": "config-plugins-QGV4cG8vY29uZmlnLXBsdWdpbnNAbnBtOjU0LjAuNQ==-8670d4e737.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.10.tgz",
         "sha512": "fc9d7a482d9a9f52ddb4267aef18529065e900b614554372670b3bbfe3d5b056710a561e8434a828bab245a1a4a47958ac2734f1b4b4445e44d0957a839d29b0",
         "dest-filename": "config-types-QGV4cG8vY29uZmlnLXR5cGVzQG5wbTo1NC4wLjEw-7e4d598d2d.tgz",
@@ -6442,6 +6316,13 @@
         "url": "https://registry.npmjs.org/@expo/config/-/config-12.0.13.tgz",
         "sha512": "0aee766ab05ae2f49aba9216b05d21ec5fc283ffcddfbe2761bec703157423829c78a03bc76517a5868738bec411862fa7bb597538418ef1a9566afc49c22f69",
         "dest-filename": "config-QGV4cG8vY29uZmlnQG5wbToxMi4wLjEz-2caac758fb.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@expo/config/-/config-12.0.14.tgz",
+        "sha512": "ddd7db05df4b9cf0e0cb29610a090eb1a1bc01d839dae3953934181f995fdb76bfb7c339790a57282bf351aaeb7fad81efcd39ee7d8d9e48a87caf537cf82fcf",
+        "dest-filename": "config-QGV4cG8vY29uZmlnQG5wbToxMi4wLjE0-cb178e5eab.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6460,6 +6341,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@expo/env/-/env-2.0.12.tgz",
+        "sha512": "c157f37811a55288591b9912f100aa5eeae9b96645244901075c170a27da8b7119fcb95c83f54c4e2502a408072260f7948ec6214dd5d6e23ae1cd385c8a3df1",
+        "dest-filename": "env-QGV4cG8vZW52QG5wbToyLjAuMTI=-cd6563d422.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@expo/env/-/env-2.0.8.tgz",
         "sha512": "e55403e864fc1c8311692681e4916d397baf7c3554f3462d648b944ff18385417bf36bac217635dd39f721d0f3d539bf96a03daa7459435045e2decb96f7493c",
         "dest-filename": "env-QGV4cG8vZW52QG5wbToyLjAuOA==-d440e0c7d8.tgz",
@@ -6467,9 +6355,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.4.tgz",
-        "sha512": "79897172b19d476fe3d8cea91035e8f7353d2975c5d6f84ff95f9397e97263e6d4f259f3acde9ceb7ee6cfa61edde9b600dcbc861511d3745a7fc56c4fd3a09e",
-        "dest-filename": "fingerprint-QGV4cG8vZmluZ2VycHJpbnRAbnBtOjAuMTUuNA==-854c5b8c29.tgz",
+        "url": "https://registry.npmjs.org/@expo/fingerprint/-/fingerprint-0.15.5.tgz",
+        "sha512": "99d56800c72ec755a533a91dd51a1688744da8aa92f89ea62a6590fc12a07a1f77ed2fdf716e7c104ebc3ba9dce0a0d7b568b73c178d1ec90e15c83222e0f887",
+        "dest-filename": "fingerprint-QGV4cG8vZmluZ2VycHJpbnRAbnBtOjAuMTUuNQ==-27b1814c3e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6488,6 +6376,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.16.tgz",
+        "sha512": "7dc5645848fe84bb8fdb2b795b46b0e8b98346a48f5832d44b138c72615e57e6a5826205e7db1054a0b007d6ed8d02dde15eb1f4dd2921291012406e6d41eb0b",
+        "dest-filename": "json-file-QGV4cG8vanNvbi1maWxlQG5wbToxMC4wLjE2-1ba48ee886.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.8.tgz",
         "sha512": "f4b3938753e02a2cc3d555df190f3c2ed0c7d25470abd96c4dbe1a89c8564d6496ab2dd481f9217e6dc187304890925f410e6226ede6fc1a11944223a0219c9d",
         "dest-filename": "json-file-QGV4cG8vanNvbi1maWxlQG5wbToxMC4wLjg=-d744edb72e.tgz",
@@ -6495,9 +6390,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.14.tgz",
-        "sha512": "871a4bc837ce4782f6ded27d5b521b249b06ee4e25bf6b28b688419bf913632886fa97b54980805ac466824f87e36a3fc167ff1d08c4e64e394b94e89862f134",
-        "dest-filename": "metro-config-QGV4cG8vbWV0cm8tY29uZmlnQG5wbTo1NC4wLjE0-c1a67c187f.tgz",
+        "url": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+        "sha512": "4ba5f329edd1f4641e1e250f5dcdf12633afd95261384c0561fef1742db3d9c52ab7791927d9923bcefbb0d425a157675bf4940ad3d8ddb7b194cee7c2af8201",
+        "dest-filename": "json-file-QGV4cG8vanNvbi1maWxlQG5wbToxMC4yLjA=-6d7f8acd34.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.16.tgz",
+        "sha512": "dcb2dbf59425d1596a4a5b1a949efe0988dfcfad0f0684831efa44d5417bd5a4ccd4dc7455be0b857a3b6c2082f8f60ff6afc63c1e7c2cb6c844e43c3e3297db",
+        "dest-filename": "metro-config-QGV4cG8vbWV0cm8tY29uZmlnQG5wbTo1NC4wLjE2-911fd5d439.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@expo/metro-config/-/metro-config-54.0.17.tgz",
+        "sha512": "3d01604026466340df7d952f07326db433eb7997c7ad06a468194a8e7bce50c3576c39daf9362683520566e20351825eccb71da7e4ef5454cb8cd8b5fa6a9a57",
+        "dest-filename": "metro-config-QGV4cG8vbWV0cm8tY29uZmlnQG5wbTo1NC4wLjE3-63da79e7f1.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6526,6 +6435,13 @@
         "url": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.8.tgz",
         "sha512": "a5f36d12b186cf34701cffb9f91aacc333c32a466bc7e0a58b49b38d06aeb3565616ca20e626cbfa7553dcd729a2b5b9d68f20827b7bc7cd77bed45b3e2c8ead",
         "dest-filename": "plist-QGV4cG8vcGxpc3RAbnBtOjAuNC44-48ba4ad5cc.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.9.tgz",
+        "sha512": "30f56998a19f9d0127ac2ce0c6e5dc98f3ffcbfb7a0159be0dc49bd8cca9db52ca5afd4dde5f2e17132081eb1f1788b103191194698c331f46c830bd33e5e495",
+        "dest-filename": "plist-QGV4cG8vcGxpc3RAbnBtOjAuNC45-8c8d396e1a.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6698,9 +6614,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.6.tgz",
-        "sha512": "9ad045222d54b18428eeb6289d81648e060a1a82fc4fe7c41fa346529beeaad637cad32c0280da3e8e6b936e4ab8cb4a0e2a58e1b19833f0a49821c0d4ddc552",
-        "dest-filename": "react-fontawesome-QGZvcnRhd2Vzb21lL3JlYWN0LWZvbnRhd2Vzb21lQG5wbTowLjIuNg==-e1660d528e.tgz",
+        "url": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+        "sha512": "c069c03e17f38af0f0056626106f0c4ab1173ebba888c328e3c367b11923d4d664a1a6b080e8a33cd02248728c604a02b2a4c14a02d3ccbe84a934d619a511e3",
+        "dest-filename": "react-fontawesome-QGZvcnRhd2Vzb21lL3JlYWN0LWZvbnRhd2Vzb21lQG5wbTozLjMuMQ==-e099a57210.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6708,13 +6624,6 @@
         "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.2.tgz",
         "sha512": "f36729c89c8a468428462fb5e226c27863eed02c32a60b4101d061ab559fbda82909934aab05db2b05e595848c1bdd438661b88edf6037c78fea518eb68cee6b",
         "dest-filename": "promisify-QGdhci9wcm9taXNpZnlAbnBtOjEuMS4y-d05081e088.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
-        "sha512": "9364f2d49715a238c9170ae0fd384a8b6ba327b5cd2d868518d07f6d64fdc0647ea123091cc6b9c3e094abaa7fa55aca78d36003ba42a847234a71d5a2a25017",
-        "dest-filename": "promisify-QGdhci9wcm9taXNpZnlAbnBtOjEuMS4z-052dd23214.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6754,9 +6663,44 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-        "sha512": "0d92c412a1564058b22ba8796087b29cac7b265bc26162f470899f4915d9f65e1283679f905193b857fabf35e32b572ae8862453e120fc98b35f0f930f6bd137",
-        "dest-filename": "config-array-QGh1bWFud2hvY29kZXMvY29uZmlnLWFycmF5QG5wbTowLjEzLjA=-524df31e61.tgz",
+        "url": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+        "sha512": "b964c6fa5dd5251b25ec45f1622cee2f73fe7023e8737711a9b59645c40dd0585e8d17db76ad113610a66d8fd80ed9d3733f6271d2d8b8b0e3b27cf877c24cbb",
+        "dest-filename": "jinja-QGh1Z2dpbmdmYWNlL2ppbmphQG5wbTowLjUuOQ==-8147f05df2.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+        "sha512": "f2b17f4514f5d2efa49fb62e51b520d0e177d0af2b8d373bf1a1e9c53faa275b964aac53d4c1e2f3ef65b7061f905609cd3fe84beab0dc955f1ed34c18076ac8",
+        "dest-filename": "tokenizers-QGh1Z2dpbmdmYWNlL3Rva2VuaXplcnNAbnBtOjAuMS4z-0a0fc0e06a.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+        "sha512": "f01442a01307d17b1668421a9ae4742eb24601f7ed80701f6f656b7dfcb454a952004fcc9d4279fe1ff34df10fddf0c87edfa793b4ea07cc571320011a2b418d",
+        "dest-filename": "transformers-QGh1Z2dpbmdmYWNlL3RyYW5zZm9ybWVyc0BucG06NC4yLjA=-5a2c769c41.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+        "sha512": "5215cd9be08531671b0a15f2c05c249a1aa3b373d10a67126bf85f0602c86fba10e4735bd704b489c5ac1ad48050d81e7c7788f9e06b03c2357f199b1ec19dbc",
+        "dest-filename": "core-QGh1bWFuZnMvY29yZUBucG06MC4xOS4y-c6c0273721.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+        "sha512": "804d5e40d67747efa44f3154a5d1a5a66cbc903643fcc2f21ea0f0aa3915408d0931d2350f9d6ccb51fde7c3cd5d890cdab01a73b7b9fc29c8299ac7b4f87705",
+        "dest-filename": "node-QGh1bWFuZnMvbm9kZUBucG06MC4xNi44-ed01b3c066.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+        "sha512": "659d70d1aa10930b94b82ed87feeec75e68d7ea42288b71245b7c8d3ca00c6a2eda5742bf402155fb032ec72c3ba22d801a14fbbca0160dabf4088bd5111c9dd",
+        "dest-filename": "types-QGh1bWFuZnMvdHlwZXNAbnBtOjAuMTUuMA==-dea3cc7fd8.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -6768,9 +6712,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-        "sha512": "f77cd874c112fdcd43ebdc9988a0c18f4576e2fa8dcc1fe4a05dba28f69a8007dddcfff8814961dc3cace688002be1318bd432ce50fcc7fd3c66def020a70370",
-        "dest-filename": "object-schema-QGh1bWFud2hvY29kZXMvb2JqZWN0LXNjaGVtYUBucG06Mi4wLjM=-05bb99ed06.tgz",
+        "url": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+        "sha512": "6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285",
+        "dest-filename": "retry-QGh1bWFud2hvY29kZXMvcmV0cnlAbnBtOjAuNC4z-0b32cfd362.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -7510,9 +7454,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@koa/cors/-/cors-3.4.3.tgz",
-        "sha512": "58f5d051a01e00c55a2d3105a68ab74f63b50be16cb648c99c342acbde4293551d20b6a3b1186eea6849f07d9fe0d14f441a0234dfaacb04c97eafe01a48b99b",
-        "dest-filename": "cors-QGtvYS9jb3JzQG5wbTozLjQuMw==-7e91b661a2.tgz",
+        "url": "https://registry.npmjs.org/@koa/cors/-/cors-5.0.0.tgz",
+        "sha512": "c7f8940e3712f745baf4faf22c320c805c95db560b4e71bdccea4f5d2ec192dd9bf00b18df366c22938b06462bf5f05c1771db90a68447984e0592dfa4b81837",
+        "dest-filename": "cors-QGtvYS9jb3JzQG5wbTo1LjAuMA==-3a0e32fbc4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -8049,13 +7993,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-        "sha512": "45304658be45590720f68ac3382729e0bbc8b4dcd43dcc8453d6f069e257d2b275210c73b9c0b8f18d3fb102e9fe0eadf7d21080094621a7ac252fa04e7eed55",
-        "dest-filename": "cross-spawn-promise-QG1hbGVwdC9jcm9zcy1zcGF3bi1wcm9taXNlQG5wbToxLjEuMQ==-8f04dcbe02.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
         "sha512": "d43a4a5346794e196d0708cdc92302d788340a46f28426b3f45921c6a36c648eae00f257152f1c3179412a8dba149f19b96e92f4608c711f483b99365f9ffd16",
         "dest-filename": "cross-spawn-promise-QG1hbGVwdC9jcm9zcy1zcGF3bi1wcm9taXNlQG5wbToyLjAuMA==-b7402d050e.tgz",
@@ -8147,6 +8084,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+        "sha512": "218a831a24d769be859e20209d2759c2059ba26c69cbd16d62f2cab3bc0252cd9af119084c6f831463b50ccf5cafe137fd18000d1a458eb295689d73eac8ed12",
+        "dest-filename": "hashes-QG5vYmxlL2hhc2hlc0BucG06Mi4yLjA=-b1b78bedc2.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
         "sha512": "beadb806adf29b91c4426d8d282af7c970f08dceef4ec1138510e7929d832bda75baa2d1f831eeae6fcd393a34286ec760753b7a9a4a663dcccaa62e3017fada",
         "dest-filename": "fs.scandir-QG5vZGVsaWIvZnMuc2NhbmRpckBucG06Mi4xLjU=-6ab2a9b8a1.tgz",
@@ -8189,13 +8133,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
-        "sha512": "c8e24a46fa2114e68baa2a4db70601f56ba0c992a10bf0d90b85583e6a5a0b30c1ac0f18a4adea1d9f3f1c6b1c3271381aa6e42cdb957029f191e404746b7a2d",
-        "dest-filename": "fs-QG5wbWNsaS9mc0BucG06Mi4xLjI=-c5d4dfee80.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
         "sha512": "ee465401a2ec71f81bc014116ef74c61a64e5b230470f4c7fed2639f201627f76fbecf447fe084471fea25bf46131269975aa2a5a0c69fb2aa1e71461a2c5dd3",
         "dest-filename": "fs-QG5wbWNsaS9mc0BucG06My4xLjA=-f3a7ab3a31.tgz",
@@ -8227,13 +8164,6 @@
         "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
         "sha512": "d5251ffc28361b3183c9a7f5e5a47d4adf535a56fe5ef6d95d6a43c7c60ab3b30bccc1ff0427a8a6ffb2f6fcebce091fca4086b963a54aede66618f6f8541cae",
         "dest-filename": "move-file-QG5wbWNsaS9tb3ZlLWZpbGVAbnBtOjEuMS4y-c96381d4a3.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
-        "sha512": "9897766794e3616abfb6d3cb2c6a80addb670bbe09e9b3b3838acc0e737ea75c5369c676c8f442936cb4a12590b7280b47d61541780e70e36bc2d9e4dc9ba9c5",
-        "dest-filename": "move-file-QG5wbWNsaS9tb3ZlLWZpbGVAbnBtOjIuMC4x-52dc02259d.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -8609,6 +8539,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+        "sha512": "ed84f453fcded2d17640e05b135e60299c32e6dbe01b22d18911cbce195b3a97fb053d37da805277485a66a5e7e56ea5dba58b96edddcb1ce333edbadfcff3d9",
+        "dest-filename": "asn1-schema-QHBlY3VsaWFyL2FzbjEtc2NoZW1hQG5wbToyLjguMA==-2964a77c29.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
         "sha512": "b655ba731a07c207108219c9c2fdd84bef4e3b5ef7ef380fa2067e0a059150ae2ba04c083f3447e091221bbef4c5ee475f60137c2a665fad20bab7d6205f5d71",
         "dest-filename": "asn1-x509-attr-QHBlY3VsaWFyL2FzbjEteDUwOS1hdHRyQG5wbToyLjYuMQ==-86f7d54954.tgz",
@@ -8619,6 +8556,27 @@
         "url": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
         "sha512": "3bd8d3e45d40dbeb77afb0b8553ecb6065ea9062caeca8f5c45a73ed4d22b0faee6f05393db0e8c98b71e8c886b2ddbdcaaee95cde6f65b40529108ffa52d994",
         "dest-filename": "asn1-x509-QHBlY3VsaWFyL2FzbjEteDUwOUBucG06Mi42LjE=-e3187ad04d.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+        "sha512": "72851fba831e201ec1f3f34c7a4c5a0f32e16989a9d0764d3c48d8466f60a11a2ef146480b7cf6d6cd2c2fd016a02c38106f3be90c8ede462b73ad56345f41ff",
+        "dest-filename": "json-schema-QHBlY3VsaWFyL2pzb24tc2NoZW1hQG5wbToxLjEuMTI=-dfec178afe.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+        "sha512": "fa82f71cf151219d52b762b9d255825e28a82204a8c73cfb475277b85ea778edb2975b209a9818e975c91f805da680e4316ce741379817aa1634364b09d43879",
+        "dest-filename": "utils-QHBlY3VsaWFyL3V0aWxzQG5wbToyLjAuMw==-e6b212db06.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+        "sha512": "3833a8bf4b0630931fde33e89ce9201aa3e49d3b2ef83750ee40fefa0cfc688f9a14c38c1c56d6000dad6aa5d755374ff8e4ce411ff39c6bd2a6691e23459361",
+        "dest-filename": "webcrypto-QHBlY3VsaWFyL3dlYmNyeXB0b0BucG06MS43LjE=-192ff15fb0.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -8644,9 +8602,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-        "sha512": "e93c849c781de9202b40ef143b638c4f1b21967dd031606d3c6ace0a0b37c15126426c32b8db41d7421931f9980c4d2b8b0351d5cbb8abea4f731315b5a1b74c",
-        "dest-filename": "test-QHBsYXl3cmlnaHQvdGVzdEBucG06MS41Ny4w-07f5ba4841.tgz",
+        "url": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+        "sha512": "3c6eaaeb79d083973dac88b8fd9e6547921517bc94e4caa629a3ce7b41d27343b6717d5f3e2f7ab1442ee63edea3880a0a4076027346a16b7bcb8fd7c7729caa",
+        "dest-filename": "test-QHBsYXl3cmlnaHQvdGVzdEBucG06MS41OS4x-27a894c4d4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -8689,6 +8647,69 @@
         "url": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.0.tgz",
         "sha512": "cebb14c632ce280cdd7b0203456cbd9ec575190b0a04259a1b0b194250a0afafeafaf8f2661160a9e74b7c506e23d6a74cf1144f800fabd32ed126414f321c19",
         "dest-filename": "core-QHBvcHBlcmpzL2NvcmVAbnBtOjIuMTEuMA==-798848cb9d.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+        "sha512": "8fe80a13112e2e62b0bf3dce811397b6b276506db1f028766195316a187eb351761d9fb001c79434b92fcbacca08f551914fbe65642b771b147905e6720e2ea1",
+        "dest-filename": "aspromise-QHByb3RvYnVmanMvYXNwcm9taXNlQG5wbToxLjEuMg==-8a938d84fe.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+        "sha512": "01991c000e6f9cdfefe0f0ea2b2311e65c7b859b6d3c380296ff3713ffc530d851d9331c2d485f4540470a64a5d288bdccc8030ea4542644b13b7c26f39f972e",
+        "dest-filename": "base64-QHByb3RvYnVmanMvYmFzZTY0QG5wbToxLjEuMg==-c71b100dae.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+        "sha512": "ce05c52f35b7029df77ba7745a58f8306226e827bc3bcf67fdaa54686341fe3c7e870fabb96129ec4c0652c85d2ca5510b1656d767e9f6be34135990adfff7e2",
+        "dest-filename": "codegen-QHByb3RvYnVmanMvY29kZWdlbkBucG06Mi4wLjU=-290335fa11.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+        "sha512": "bd6d469b03193672fe80c45aa2f961f72657ef891cf934d4dc539b924baba4c691b417cb3f795d8d2f4a416970660ada444d3e76178412803177370943c79766",
+        "dest-filename": "eventemitter-QHByb3RvYnVmanMvZXZlbnRlbWl0dGVyQG5wbToxLjEuMQ==-a54dc1aff4.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+        "sha512": "1a9a6d2ebb39eda74c4ae1e2dd5363d26005f1dc21dfa2cc69817a5f227a24c5a556c73eb78dad9b51d210398eb3703c7c2f72c9e8ac80b86c4d542890e674cf",
+        "dest-filename": "fetch-QHByb3RvYnVmanMvZmV0Y2hAbnBtOjEuMS4x-427cf2da8c.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+        "sha512": "0dd6fe9155e55ecb7d77e47d3df4c8c61d4474d920a117b9b4e5fab74d5fd656163af26748f0c1946db8d502f37323dda0d4ec6e52d476e8c6484e11ceb4d919",
+        "dest-filename": "float-QHByb3RvYnVmanMvZmxvYXRAbnBtOjEuMC4y-634c2c989d.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+        "sha512": "e8939c2794e6d3c74e1c06dd4771abbcffb25147e48c6e5e3ec1d87333052eadd998c9000fdf1c0e0713da2035949f4d57015de2d1ff8924a87b8e185a496d10",
+        "dest-filename": "path-QHByb3RvYnVmanMvcGF0aEBucG06MS4xLjI=-bb70956793.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+        "sha512": "d2410b6864880c12af7204b8ce48f3d4f79d75ab6b8d87263163a502e00fc0079c714acf1dd52aa3f27a2e2ca61c7122253e4dac5d54570c58d787fe7f2e1643",
+        "dest-filename": "pool-QHByb3RvYnVmanMvcG9vbEBucG06MS4xLjA=-b9c7047647.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+        "sha512": "a0e016001a307bc1006ccc9628cd2d6032a2f186a8c79d83f87599840209a905dba9ed3123f195ec584b5aa9442ab78c91f0e3b2147914a822de69e57b487a12",
+        "dest-filename": "utf8-QHByb3RvYnVmanMvdXRmOEBucG06MS4xLjE=-ed0c3f9ff1.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -8868,9 +8889,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.5.1.tgz",
-        "sha512": "4eec0cd4e45bc428cea7518eb4e363d109e90e955fab41785257ca6583f12ffbe6ae268b1edd8a82fc3adc1bf40697a9e1e3a4b25555492d4845f448e9ddfdda",
-        "dest-filename": "datetimepicker-QHJlYWN0LW5hdGl2ZS1jb21tdW5pdHkvZGF0ZXRpbWVwaWNrZXJAbnBtOjguNS4x-6d28e8fc00.tgz",
+        "url": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.6.0.tgz",
+        "sha512": "cb13d2a8d7f182919aa87408a5ab6a7baca4781754ff5a5db24fc6df1d35998d9ba537e52e99954cba8548961ddcc899cf135970cb3f8f57506a451ccd28dc60",
+        "dest-filename": "datetimepicker-QHJlYWN0LW5hdGl2ZS1jb21tdW5pdHkvZGF0ZXRpbWVwaWNrZXJAbnBtOjguNi4w-8d287227ce.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -8882,9 +8903,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
-        "sha512": "074058024821cf7436574f4117cf1103ad355eeaec204035d75b6773624e68dedac495a635e7e67e366ac3f29d4b1299a7b09952e3e98c19b3fd6091f6e68762",
-        "dest-filename": "netinfo-QHJlYWN0LW5hdGl2ZS1jb21tdW5pdHkvbmV0aW5mb0BucG06MTEuNC4x-47f0d61072.tgz",
+        "url": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.5.2.tgz",
+        "sha512": "fe0d26eb906d5fd1d4f9b3e2087db9d7b6ce1e910852c1ab5855c3ce2d5ae6734a9f92ae8d0826d385a12fbfce49758a1f2ad3f1556d528240d17291c6e781a5",
+        "dest-filename": "netinfo-QHJlYWN0LW5hdGl2ZS1jb21tdW5pdHkvbmV0aW5mb0BucG06MTEuNS4y-0c388e1beb.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -8896,23 +8917,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native-documents/picker/-/picker-10.1.7.tgz",
-        "sha512": "4dbf123d4fa91f1ad22660c7068cd2512b483dec851d31cbad4dcc5b4377b14022a0b779cfe9e651dca97e0e5fb3e633a7b293c555b4e803ded872c1d72b0bc3",
-        "dest-filename": "picker-QHJlYWN0LW5hdGl2ZS1kb2N1bWVudHMvcGlja2VyQG5wbToxMC4xLjc=-b9f629501d.tgz",
+        "url": "https://registry.npmjs.org/@react-native-documents/picker/-/picker-12.0.1.tgz",
+        "sha512": "be924a6f8b7fe5b9f17bdfa0425fa99497caaeb22c998c0034684d1f607d135752d7ee850c1ce0e03c2672ae2e79a19f9112843c9eb4ea626db55107d5929968",
+        "dest-filename": "picker-QHJlYWN0LW5hdGl2ZS1kb2N1bWVudHMvcGlja2VyQG5wbToxMi4wLjE=-5d915828a2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native-vector-icons/common/-/common-12.4.0.tgz",
-        "sha512": "b7d5b4abe016ed61f53a3e5a120ef018d5c32d925be6c2159005a8e6ab5a7773dc6c1003aa809d8a444afd3a0b2bec650744f18dcb8bd13ef8a20b9d32460678",
-        "dest-filename": "common-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvY29tbW9uQG5wbToxMi40LjA=-9c59a8c21f.tgz",
+        "url": "https://registry.npmjs.org/@react-native-vector-icons/common/-/common-12.4.2.tgz",
+        "sha512": "d79562bb07d876443bf5513a3e2423b06c90704be1bf896082e848790538a572d744016197cf50f0574a0eb19987bf9affc58ca93d6fdbe26d82176818a0c4e9",
+        "dest-filename": "common-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvY29tbW9uQG5wbToxMi40LjI=-563d212608.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native-vector-icons/fontawesome5/-/fontawesome5-12.3.0.tgz",
-        "sha512": "c7f112979d5ff764ab24ed4022811462188381fed3ee579889bec7eb94cf0aa334475866a008679fcc13d09cc44cb9f9816775d6fda773b04b81c84edc17c3cc",
-        "dest-filename": "fontawesome5-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvZm9udGF3ZXNvbWU1QG5wbToxMi4zLjA=-d11626e7cc.tgz",
+        "url": "https://registry.npmjs.org/@react-native-vector-icons/fontawesome5/-/fontawesome5-12.4.0.tgz",
+        "sha512": "ed12f4c2c75242dfb5651bcb4e99d0aa6a896e0deab466b86c2f4b6aa59214c6c6ea0a319a40e47b081fb11cc09c7d3184bb9d75a2420e2e24f2106b45ef3315",
+        "dest-filename": "fontawesome5-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvZm9udGF3ZXNvbWU1QG5wbToxMi40LjA=-087dd587ba.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -8924,23 +8945,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native-vector-icons/ionicons/-/ionicons-12.3.0.tgz",
-        "sha512": "1ffae56335049b4861c3071ada4e9530d8f2d2b2dc8da9fa8b0c9a6035cc86c25097b3b8f90926eee55dfca12b792e605df1ae9ed5257126bd1929fe758aa78c",
-        "dest-filename": "ionicons-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvaW9uaWNvbnNAbnBtOjEyLjMuMA==-da342a72ef.tgz",
+        "url": "https://registry.npmjs.org/@react-native-vector-icons/ionicons/-/ionicons-12.5.0.tgz",
+        "sha512": "99e8e3275889cdbb3cb2ac5a8e4235315950d4ad9ffa857f51fe23955128b56a5c4dd502ca4452a97ca538c53c51455b19228047dedf99a2ff251c5a016bc436",
+        "dest-filename": "ionicons-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvaW9uaWNvbnNAbnBtOjEyLjUuMA==-cb94eb6699.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native-vector-icons/material-design-icons/-/material-design-icons-12.4.0.tgz",
-        "sha512": "e1ec0088774e0ae8eaa6b5096059c171425db8d75d01cfb0dcf967975361264b00c8e687cc2341834d49815b64cacc4f868ebef8e38c81edc5870c814fc5ad72",
-        "dest-filename": "material-design-icons-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvbWF0ZXJpYWwtZGVzaWduLWljb25zQG5wbToxMi40LjA=-15227f2aca.tgz",
+        "url": "https://registry.npmjs.org/@react-native-vector-icons/material-design-icons/-/material-design-icons-12.5.0.tgz",
+        "sha512": "2ed9a6970fefb250df1679a2f1a284f90a12ca9a62fad2cd4050aab1ae5820f07028231a44f9e8374319b5cf025450bc63ad424d37260201be72fcf0df3c0b88",
+        "dest-filename": "material-design-icons-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvbWF0ZXJpYWwtZGVzaWduLWljb25zQG5wbToxMi41LjA=-ccc04ababe.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native-vector-icons/material-icons/-/material-icons-12.4.0.tgz",
-        "sha512": "4740b6041a19679b2364960b6c5c75bdfc98c1f6ce7011d16334470ca525b0276995cdf81cb6b42721d818c1b1deae711c0241e839783767266545402ee27ad3",
-        "dest-filename": "material-icons-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvbWF0ZXJpYWwtaWNvbnNAbnBtOjEyLjQuMA==-472eb93fe5.tgz",
+        "url": "https://registry.npmjs.org/@react-native-vector-icons/material-icons/-/material-icons-12.5.0.tgz",
+        "sha512": "3abb50d9ecf1650fb4e89e914e5352fa2d8532cb32f9576e5e766b10e9d6fe27cb03bb15794b02c9a2b8c21e6ee0034a98f920d842a596d28e93d40d2d8cb8b2",
+        "dest-filename": "material-icons-QHJlYWN0LW5hdGl2ZS12ZWN0b3ItaWNvbnMvbWF0ZXJpYWwtaWNvbnNAbnBtOjEyLjUuMA==-4e7824c145.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -9106,9 +9127,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@react-native/typescript-config/-/typescript-config-0.81.6.tgz",
-        "sha512": "d5ebbad2295b4fc766f1eb93bf39a5a90fa80b679bd20ea15c472f563fd326d2d60cb97b192980993f280fee78e390f5cd388420c221a4aef43803e0a1193fce",
-        "dest-filename": "typescript-config-QHJlYWN0LW5hdGl2ZS90eXBlc2NyaXB0LWNvbmZpZ0BucG06MC44MS42-bfde8a7213.tgz",
+        "url": "https://registry.npmjs.org/@react-native/typescript-config/-/typescript-config-0.83.1.tgz",
+        "sha512": "cbcdea77b7e69591be109a0ec8a12601789f76337572c36171fa72c43be068850d3bfa70db0b37315ff0a7e11143c17a248b80bb5cdc7f20b2d7fa4403bb42f6",
+        "dest-filename": "typescript-config-QHJlYWN0LW5hdGl2ZS90eXBlc2NyaXB0LWNvbmZpZ0BucG06MC44My4x-fb0d4716fb.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -9134,9 +9155,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.9.tgz",
-        "sha512": "3c8478fce1d9efdae89b1d01555965fcf9305a927b7b996ca856b78057dcac53d6c0b5cb577f49554cd057d44a8d67ab13b07ce391ea8e3f5562541e89e67674",
-        "dest-filename": "plugin-commonjs-QHJvbGx1cC9wbHVnaW4tY29tbW9uanNAbnBtOjI4LjAuOQ==-68b040339a.tgz",
+        "url": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.3.tgz",
+        "sha512": "65a3b165c78fed23945bb2eac3921157079241859a7883e75c818b881ebdd04040dc51894cee34104af62f9c99a65256b204c2a2020b452a5c01eefe5343ad76",
+        "dest-filename": "plugin-commonjs-QHJvbGx1cC9wbHVnaW4tY29tbW9uanNAbnBtOjI5LjAuMw==-2331da36b6.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -9498,13 +9519,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@smithy/core/-/core-3.18.4.tgz",
-        "sha512": "a39b4ca8f6482c1bef44e7c2f2f0be75256758997d6b4bbd6b1d62d7e06af39d797988d426aaa4e578e312c0cba1e2f9752a864a1e9619d571d5e27513f37087",
-        "dest-filename": "core-QHNtaXRoeS9jb3JlQG5wbTozLjE4LjQ=-a3eef0728c.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
         "sha512": "059c28b63a195a7f7edfa9e29b09bf38b21c55ef8a611c333237e1778413ed0c4f9bd598d0788e57cb7f5a587e1d55227f4481555ee4b2af3ffe13da042fe891",
         "dest-filename": "credential-provider-imds-QHNtaXRoeS9jcmVkZW50aWFsLXByb3ZpZGVyLWltZHNAbnBtOjQuMi41-45ce1b74f3.tgz",
@@ -9610,23 +9624,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.11.tgz",
-        "sha512": "7895eaf5527311eaf55bb1108771d8d8f0c9744704527bfab0ab8db787958f278d59c4054b82a69d8f822a460e211ead4aa6ab9fa6e38c2aa0d5407ef142623d",
-        "dest-filename": "middleware-endpoint-QHNtaXRoeS9taWRkbGV3YXJlLWVuZHBvaW50QG5wbTo0LjMuMTE=-932fe6d682.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.9.tgz",
         "sha512": "21f1c1929b26abcbffee3bb6e02333276f691c7e2035e32234c085d62bc25612c82cde31b665279e58619b44b7ed1e0361d68d67e605328a688e1d9d14f148c7",
         "dest-filename": "middleware-endpoint-QHNtaXRoeS9taWRkbGV3YXJlLWVuZHBvaW50QG5wbTo0LjMuOQ==-cb17ff4dbb.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.11.tgz",
-        "sha512": "10be4e407bc538a9de255460cd15b8954ef289d4b0a7fbd124e7b9e366c7804c4ddca35386bd6b960d221389384a703ea210beaa5531a0afac98a78060fcdf01",
-        "dest-filename": "middleware-retry-QHNtaXRoeS9taWRkbGV3YXJlLXJldHJ5QG5wbTo0LjQuMTE=-63f18b14e4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -9641,13 +9641,6 @@
         "url": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.5.tgz",
         "sha512": "2dad657564c94d9e4da90c8faa708d787f41fb38c586b3684082f58d3878ceea9746599787160784cb48d7ff763a59e802da7a26837b933bb0856a17ac1c0faa",
         "dest-filename": "middleware-serde-QHNtaXRoeS9taWRkbGV3YXJlLXNlcmRlQG5wbTo0LjIuNQ==-32c6310ea4.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
-        "sha512": "5642e813fcfb7b683ca62af08ac2f3f1725679d51263c9b2feaae9f3556601dcab862f784feae205fc0ff8038410547dac54d2a270bfe43d9e58d98569b1f219",
-        "dest-filename": "middleware-serde-QHNtaXRoeS9taWRkbGV3YXJlLXNlcmRlQG5wbTo0LjIuNg==-87aa0c6bf9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -9729,13 +9722,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.7.tgz",
-        "sha512": "a6c91a138920d0ff713505a285faa54cccb1c85477087e92afa91e1d8821832aaa0d7ce3976409839940cee55efcbcd988ecdc6dc56dc4a622d7f7d93edff70c",
-        "dest-filename": "smithy-client-QHNtaXRoeS9zbWl0aHktY2xpZW50QG5wbTo0LjkuNw==-4752673e87.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
         "sha512": "32f51b7675c34f0ca447c701d5666f34dc2aa1655a4d103444b94b99ffdc20534c33670a5b3d355f82f2e92302e0a92cdf4afcb53dc2b72d2399e59f8aec874c",
         "dest-filename": "types-QHNtaXRoeS90eXBlc0BucG06NC45LjA=-b966ddb054.tgz",
@@ -9792,13 +9778,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.10.tgz",
-        "sha512": "de20372553b554bacfdb516c659a4c09e17dddaa8fdee20e32fca6013dea1c8273d989600de46f354b2917008da9dfe3deaa882d0246b6c5509c96480a1ffd60",
-        "dest-filename": "util-defaults-mode-browser-QHNtaXRoeS91dGlsLWRlZmF1bHRzLW1vZGUtYnJvd3NlckBucG06NC4zLjEw-78dc8eee11.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.8.tgz",
         "sha512": "974ff1a01991a25433359a16f0291038e222ebba666de6f2092b811e473aba0e316744d77116aae898dad2df89083a10403d9644e03c218286e947c6ab8f1798",
         "dest-filename": "util-defaults-mode-browser-QHNtaXRoeS91dGlsLWRlZmF1bHRzLW1vZGUtYnJvd3NlckBucG06NC4zLjg=-9be889eb1b.tgz",
@@ -9809,13 +9788,6 @@
         "url": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.11.tgz",
         "sha512": "0fa9f84c7ace66a13a9ab3468d9a6edb0f3371d0dc806873d07cadbeba04e6c0e64d7cab2953b8c24d47cc331c2dcc2122fb05c66450b5413d67e79c2067fbc7",
         "dest-filename": "util-defaults-mode-node-QHNtaXRoeS91dGlsLWRlZmF1bHRzLW1vZGUtbm9kZUBucG06NC4yLjEx-f070556957.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.13.tgz",
-        "sha512": "3d373a2299e9486012bb364083252d6957ce1695348c10f699c1b0ae00ee1dfecf94582de5320fc426010db150b34ea3c60795de477f77fb28935a735749c946",
-        "dest-filename": "util-defaults-mode-node-QHNtaXRoeS91dGlsLWRlZmF1bHRzLW1vZGUtbm9kZUBucG06NC4yLjEz-965c05a7cd.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -9984,6 +9956,13 @@
         "url": "https://registry.npmjs.org/@styled-system/variant/-/variant-5.1.5.tgz",
         "sha512": "627f215c0168588ae8f3e43927c60977f98ff394de8aeb777ec19547d080c7080d7c8022aa5631b24e621d4ed51c992cff42a32f80134a399bb420c2ff8975ab",
         "dest-filename": "variant-QHN0eWxlZC1zeXN0ZW0vdmFyaWFudEBucG06NS4xLjU=-170b7dd0ab.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz",
+        "sha512": "9cf2b9d991efa2df09bbfd00e2e7125f575c3d5dbfd5c971d242dc1f9c039ab1389da2aca3b4d40bfbe85325353bd393293ad1e8c622a7a2cfd28804310f633d",
+        "dest-filename": "eslint-plugin-QHN0eWxpc3RpYy9lc2xpbnQtcGx1Z2luQG5wbTo1LjEwLjA=-d55706b09a.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -10247,9 +10226,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
-        "sha512": "0cd12cfd0be6c912eeadd40f0a1aaad0c778cc6bcfc077ab00961693d9768c26c3d553e99f3449a2b39d8aae33b30d3d3456d89e17eca04856b712335e99f6cb",
-        "dest-filename": "adm-zip-QHR5cGVzL2FkbS16aXBAbnBtOjAuNS43-24e9842bd6.tgz",
+        "url": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+        "sha512": "455547ed0bd961b37e8a1a99e245ff74c8a8c1fea8f899357cdc2249dc7435a84124b53bf3bce450b84684933c99ffe86e62c69a074c3346d7b104e6c9f6d1ed",
+        "dest-filename": "adm-zip-QHR5cGVzL2FkbS16aXBAbnBtOjAuNS44-0739e5abda.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -10257,13 +10236,6 @@
         "url": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
         "sha512": "adf4fddee8f9b343d12fb13371c18cb376eba6585cae08670e8576e8da8a842012d61568f9674db0fbc4ff26fa8a57ebe618b630493a77911625329dc60f2357",
         "dest-filename": "aria-query-QHR5cGVzL2FyaWEtcXVlcnlAbnBtOjUuMC40-c0084c389d.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@types/asn1/-/asn1-0.2.4.tgz",
-        "sha512": "57dd43489da5d21d2046154fe2805f07344137d9406cf5241833029f079da8f297d9df3868031cf42ba53afc5dc357fb0df118c7df5a7da6fe46c9b77b9da384",
-        "dest-filename": "asn1-QHR5cGVzL2FzbjFAbnBtOjAuMi40-01fee5a896.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11101,9 +11073,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.21.tgz",
-        "sha512": "122c7eb1bfcd8f6f0c3675af3b65f538bae4e6fb83e02f523276f655fe22b569f1a6161e49c7aa9055fb21d9b14f39fe76f9a7373ee968c6e0e1473ad3049f26",
-        "dest-filename": "nodemailer-QHR5cGVzL25vZGVtYWlsZXJAbnBtOjYuNC4yMQ==-3388d11def.tgz",
+        "url": "https://registry.npmjs.org/@types/node/-/node-25.9.2.tgz",
+        "sha512": "1b4e73aad2617032dbf2eb257f91230b15e0f46d4a431895f0e4b4476e880bffc4a328adcea7bccf7ec8edcaaf9d996b9527e0a1c4117d29ff0070592491721b",
+        "dest-filename": "node-QHR5cGVzL25vZGVAbnBtOjI1LjkuMg==-4ec76a3c9d.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.23.tgz",
+        "sha512": "685577fcdb1814b4b1f666dbe60b62ac1497267025aeeb2828db8f6f1b0049673bbeb28b988ad3411a5d73135c4852f7556d80d97a5e2c46afc1bdaa322ea795",
+        "dest-filename": "nodemailer-QHR5cGVzL25vZGVtYWlsZXJAbnBtOjYuNC4yMw==-2cd9713e87.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11132,13 +11111,6 @@
         "url": "https://registry.npmjs.org/@types/pdfjs-dist/-/pdfjs-dist-2.10.378.tgz",
         "sha512": "4d17483ea76cbca98f95ae38915cb88efe4db79be331f5636c81247b509150b22bc0a3510b8948899bcd60326f6d430d0853cd21470e2a15d3c8c26b5f5f0830",
         "dest-filename": "pdfjs-dist-QHR5cGVzL3BkZmpzLWRpc3RAbnBtOjIuMTAuMzc4-36dd6010f7.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/@types/plist/-/plist-3.0.2.tgz",
-        "sha512": "50baaf64d18cbf4cd116faa7f3fe0b48fb6798de0c7e194f36d2424e92ae208c46546676ad85b3157aef101a21f42572a9213b0fa605449d61c9d2c723a91b5b",
-        "dest-filename": "plist-QHR5cGVzL3BsaXN0QG5wbTozLjAuMg==-676f85127f.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11276,16 +11248,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-        "sha512": "db570526bf73de0e5d5bc07409523d8363bd6dea9a4e1190e99141a877f08732c3294c5aa93232def9df6a1fd43e47ce885da92eafad1b3f96f11c82b24bac97",
-        "dest-filename": "semver-QHR5cGVzL3NlbXZlckBucG06Ny4zLjEz-0064efd7a0.tgz",
+        "url": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
+        "sha512": "7094505e939bc5f34a9050196c9976ca35ad242a842d021d4a1b2882bd5dd8c8a53fc74a0fd4c4fe710a1e426050d1dd18a09069ff476c8ca7b95d9cb0b1952e",
+        "dest-filename": "semver-QHR5cGVzL3NlbXZlckBucG06Ny41LjE=-8e19822a2f.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/semver/-/semver-7.5.1.tgz",
-        "sha512": "7094505e939bc5f34a9050196c9976ca35ad242a842d021d4a1b2882bd5dd8c8a53fc74a0fd4c4fe710a1e426050d1dd18a09069ff476c8ca7b95d9cb0b1952e",
-        "dest-filename": "semver-QHR5cGVzL3NlbXZlckBucG06Ny41LjE=-8e19822a2f.tgz",
+        "url": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+        "sha512": "1668097eef8c39c437ef4483d1ebfb108f1394201f29853e0789b94f7c977350a244df7883f4993edb02924e74e9a503b65327159bdab03c071d4719504698b8",
+        "dest-filename": "semver-QHR5cGVzL3NlbXZlckBucG06Ny43LjE=-8f09e7e6ca.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11346,9 +11318,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/serviceworker/-/serviceworker-0.0.179.tgz",
-        "sha512": "d8f319fe2e4c2f3970c58f4d1192eb8c2e991cf08ee2f62b54e6bdc6003b4a841022509c14a5b144b3f5a81091d4158978734761ea00736c28f8e908072e3dea",
-        "dest-filename": "serviceworker-QHR5cGVzL3NlcnZpY2V3b3JrZXJAbnBtOjAuMC4xNzk=-cc52b6ffe1.tgz",
+        "url": "https://registry.npmjs.org/@types/serviceworker/-/serviceworker-0.0.197.tgz",
+        "sha512": "3da78e1581dc47673b82e067f4ce18e47d7efac9e5b8763367a0f3cd10947fa92e7b61457e94e317cd9a66adf50c9d9cfd0c9bdca19fe513901ff7ce53c35dc5",
+        "dest-filename": "serviceworker-QHR5cGVzL3NlcnZpY2V3b3JrZXJAbnBtOjAuMC4xOTc=-664e71c44a.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11451,13 +11423,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@types/verror/-/verror-1.10.6.tgz",
-        "sha512": "34d9be81d78f017d551af3dc19908329064a6128805a280a84a6b3e4a17de211ba7f6b3c75ef4ec39fbb01b5e878ac4bf206af65f93852ab9203280e17676e11",
-        "dest-filename": "verror-QHR5cGVzL3ZlcnJvckBucG06MS4xMC42-650620b851.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/@types/ws/-/ws-8.5.10.tgz",
         "sha512": "be641251c7da96922ad11f6aeee4e8da55ece9e188a6df70b672dd32ff4b569223080ffeb9f651a33955a157a52188b1c75ba0081283867f3dbe7b0418e0b1f4",
         "dest-filename": "ws-QHR5cGVzL3dzQG5wbTo4LjUuMTA=-9b414dc5e0.tgz",
@@ -11542,6 +11507,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
+        "sha512": "4186ffb1aef8fecece28c6c008c8eb6271aca63f47b39608e5a69f7d22fae547de054cd5cc125f568de8592a5bccfbabbe6ef26820a8d8b93b9558fad741ea2b",
+        "dest-filename": "eslint-plugin-QHR5cGVzY3JpcHQtZXNsaW50L2VzbGludC1wbHVnaW5AbnBtOjguNjAuMA==-aec6f08be0.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
         "sha512": "b5bb15d633e77b90a41500a03c17033addf422d17b689a192fdf7b25217b321190a8e793decbd6458c62aa57c0e5151d94737a162f8423d6f1a9b77201466361",
         "dest-filename": "parser-QHR5cGVzY3JpcHQtZXNsaW50L3BhcnNlckBucG06Ni4yMS4w-4d51cdbc17.tgz",
@@ -11556,6 +11528,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
+        "sha512": "7dcaa98ff3322b8b310cf71b7bb49334f6e940be112d938f5ae6939b0658b9cfa124acd17f9f324717e1a86a5ce8f22af59c9f481a5f1e09941e61ecd0ac07c2",
+        "dest-filename": "parser-QHR5cGVzY3JpcHQtZXNsaW50L3BhcnNlckBucG06OC42MC4w-f55fa3547e.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.1.tgz",
         "sha512": "558c67ff92cea55c400c0b8fdcdae7c711d87f356d4332ca7a57488438730bc5076a242f6255ef2ae561a35a8b76e15b2638f2e54e5b906c1adeb50651bd50e9",
         "dest-filename": "project-service-QHR5cGVzY3JpcHQtZXNsaW50L3Byb2plY3Qtc2VydmljZUBucG06OC4zNS4x-f8ceb1c6ab.tgz",
@@ -11563,9 +11542,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.54.1.tgz",
-        "sha512": "cd62ae1a5897c6fbb1c8cef5500fc470fc5abe2c37f5d076e74e0ba809850e39a4a4ef2a34b1dc9b3961ea96c7b3587fed843d6e7b0ef0209c602480f2cca452",
-        "dest-filename": "scope-manager-QHR5cGVzY3JpcHQtZXNsaW50L3Njb3BlLW1hbmFnZXJAbnBtOjUuNTQuMQ==-f5da91d2d4.tgz",
+        "url": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
+        "sha512": "699bbbe0d34a25e516a828c375dcdd88a692f3676062057fbe67fe522dd97597a39a07d747fabea51ba68286e74367022538064d6a78ca98b0b2ea1f16e6dabe",
+        "dest-filename": "project-service-QHR5cGVzY3JpcHQtZXNsaW50L3Byb2plY3Qtc2VydmljZUBucG06OC42MC4w-21e233d129.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11584,9 +11563,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
+        "sha512": "a45cea86594932cfa38212d05b3574d1db37f712f3bb2a8f49ebf9a5df1fe08af4aed291dd92d4078ff87618ce16282159bf656abbed7c9bea2fee322832375f",
+        "dest-filename": "scope-manager-QHR5cGVzY3JpcHQtZXNsaW50L3Njb3BlLW1hbmFnZXJAbnBtOjguNjAuMA==-c08274fdb3.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz",
         "sha512": "2b9fd4f55993f5d4c7a0da30599a73fbf4ce6d2df1a82e61d310088d73f0f8c35c295f6a83a7926ad12799e0309231e28e10021f4fcdedb9212af6edd7e0d759",
         "dest-filename": "tsconfig-utils-QHR5cGVzY3JpcHQtZXNsaW50L3RzY29uZmlnLXV0aWxzQG5wbTo4LjM1LjE=-6b6176ec7d.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
+        "sha512": "0593d1dd11989405e7972eb2980c5f9159f9ac26d9cd0368bb4af1bf719f599f1c4d0a7e86155def79216c62c077c9354e500f2c8487df7eccfad0200276890d",
+        "dest-filename": "tsconfig-utils-QHR5cGVzY3JpcHQtZXNsaW50L3RzY29uZmlnLXV0aWxzQG5wbTo4LjYwLjA=-d82cac7dec.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11605,9 +11598,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.54.1.tgz",
-        "sha512": "1bdfb5bd56b3adf01f6ed9826a9257f23468d84e0c0d7c609bf20c385e281a1de4abb5ee2b725190e83acb642ed55b134665844f24e45add70c72ed7effc8b93",
-        "dest-filename": "types-QHR5cGVzY3JpcHQtZXNsaW50L3R5cGVzQG5wbTo1LjU0LjE=-8adb106d74.tgz",
+        "url": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
+        "sha512": "497e3ac0452d8ad0a9abb00ddfc1e4514ffecef52974a7fb7a986d5801607241fc3bb3d02322f982fae142004bb846202dfb8a58e56f595b2431bb851c0cf9c6",
+        "dest-filename": "type-utils-QHR5cGVzY3JpcHQtZXNsaW50L3R5cGUtdXRpbHNAbnBtOjguNjAuMA==-4b29dcc1ee.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11633,9 +11626,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.54.1.tgz",
-        "sha512": "6e32b9b7e4ba7df1e7570034a913d366bc4a49a158a1cc05224671e64ee9bd67ec075239ee93bfd0cd1291ab73cf0d6c0a48c9f3701f1932f4a052058835f76e",
-        "dest-filename": "typescript-estree-QHR5cGVzY3JpcHQtZXNsaW50L3R5cGVzY3JpcHQtZXN0cmVlQG5wbTo1LjU0LjE=-0d463a694b.tgz",
+        "url": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
+        "sha512": "02c13bc765da00af8255b7a287416f6e7fabd6a1f1b692c32775d4b857088a74f7d7c4fdd321cc242f9982ffa352e0e3410774e872b0c670eeeaccf521c4e294",
+        "dest-filename": "types-QHR5cGVzY3JpcHQtZXNsaW50L3R5cGVzQG5wbTo4LjYwLjA=-8c6967503b.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11661,9 +11654,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.54.1.tgz",
-        "sha512": "218e5dc9033c5c3d737c37b95fc8de817eabd84554e68fd62672eeff39cb3d608117b28d182f9a75a7179ede631184bd262c4372871c23a0af1384428c733309",
-        "dest-filename": "utils-QHR5cGVzY3JpcHQtZXNsaW50L3V0aWxzQG5wbTo1LjU0LjE=-90d6198de2.tgz",
+        "url": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
+        "sha512": "dc071934118c0a59ba0970f2a3c918bd5193fecc76f6c4b4a01b086fda1923682e9c0e159b6337607cd12cfbec50106c97ec81e453ed96dabb8061f4893969f6",
+        "dest-filename": "typescript-estree-QHR5cGVzY3JpcHQtZXNsaW50L3R5cGVzY3JpcHQtZXN0cmVlQG5wbTo4LjYwLjA=-ad02384fd4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11682,9 +11675,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.54.1.tgz",
-        "sha512": "abc892a074e0c027e0711276976c7ec426eef2706544096c437de4db801d8fc7a85411347fc754788f9b01af05f3832fd395066c0c79ee0db3ad1b18228a2a42",
-        "dest-filename": "visitor-keys-QHR5cGVzY3JpcHQtZXNsaW50L3Zpc2l0b3Ita2V5c0BucG06NS41NC4x-3541365068.tgz",
+        "url": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
+        "sha512": "1ed5ee3dfac74f204391a99e5a997ebc96f551ebeedadce70326a133539ce0010d89d08b4cf8990d6228e067dcc4d742fd171f19c69dcf392a6d11bcedd52b40",
+        "dest-filename": "utils-QHR5cGVzY3JpcHQtZXNsaW50L3V0aWxzQG5wbTo4LjYwLjA=-9fc8bc7a62.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -11710,9 +11703,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-        "sha512": "cee55d16b3098ae083414302cd0683e8a2f6f0c8e7aaa37c5e702a884abd3cd9bf8423d34867eb5c239fc23d68c382c56ffb4dca624fc2c35b55e3dcd7116aad",
-        "dest-filename": "structured-clone-QHVuZ2FwL3N0cnVjdHVyZWQtY2xvbmVAbnBtOjEuMi4w-c6fe89a505.tgz",
+        "url": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
+        "sha512": "f56239dadf1918b546acf3017addb9c807eda98fe7f79fb39a8514b4904141328348a52eeceb0f4eba13da8a7b53d25ab64a1171c2f462458334c15f0b84a3c6",
+        "dest-filename": "visitor-keys-QHR5cGVzY3JpcHQtZXNsaW50L3Zpc2l0b3Ita2V5c0BucG06OC42MC4w-4854d08416.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -12151,6 +12144,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+        "sha512": "291633c5ea5cd781bf084a4419cdd89fe24a680793eb7b26943afebe307c8d17e04c1048f70463fe791010efae715f29f08f5b7ca2d6a77eee1e016b6e7b4fbf",
+        "dest-filename": "xmldom-QHhtbGRvbS94bWxkb21AbnBtOjAuOC4xMw==-f8f3d56fa9.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.8.tgz",
         "sha512": "d0b373e0463c07ff315d8f3ac0cad0e2dcfacc41d9bfd7a114c24f9bcbb682ae6543bd5c7d129d68acb17c9031e5a528cb3c74ab381445b9538ac3c6833dddf9",
         "dest-filename": "xmldom-QHhtbGRvbS94bWxkb21AbnBtOjAuOC44-f4c51f1997.tgz",
@@ -12168,6 +12168,20 @@
         "url": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
         "sha512": "36e1ea058d4f07f0fcc54eacfed84180e02200fec73980d0df6f8115920b27c8af9149001d09d67e7e9684befd3b08f5aa6527a0dfd83e192d748a2e722a6401",
         "dest-filename": "long-QHh0dWMvbG9uZ0BucG06NC4yLjI=-7217bae9fe.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+        "sha512": "0a0222e87c257075f09644e9af47f12efff4b1154d67c21dc0a2f3cde0ac71a601c29bdf707d5014e09e6930ae127d45404b3f07c0a39d34a386cf2e76098181",
+        "dest-filename": "react-QHh5Zmxvdy9yZWFjdEBucG06MTIuMTAuMg==-92f341f31d.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+        "sha512": "86fc2f9d14b5077444c150e559ec6cabb61068f65e1b7fe62a8d63bf7f149a7a569b18a1a75e1b5ba56d10eb87130257d85bf3170f24efb2f229293fc2265534",
+        "dest-filename": "system-QHh5Zmxvdy9zeXN0ZW1AbnBtOjAuMC43Ng==-6fada3ea58.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -12221,9 +12235,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/abcjs/-/abcjs-6.5.2.tgz",
-        "sha512": "5cb0d93f2ff84d96cea8fb0bc2ebb4526b25efd35301c39b1246e83f175865723cfdf53a3cd879f520279193a710f55bc93f045df0548e03687bfb8a7774f4c5",
-        "dest-filename": "abcjs-YWJjanNAbnBtOjYuNS4y-9e746c7127.tgz",
+        "url": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+        "sha512": "6b5c1f97268bd2d1ed25298b48e5726d8872db6bd18a1e1e76e861ae472382b5869d17eb66da2f2761518f1b93b64923e3b3bf6da7f447ce905393ae629cfc7c",
+        "dest-filename": "abbrev-YWJicmV2QG5wbTo0LjAuMA==-e2f0c6a670.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/abcjs/-/abcjs-6.6.3.tgz",
+        "sha512": "05eac624263cfa9bc9575f95c599f563f54d72e48093c072b026c12026345bc7e01398385bab00ff3079a4ac5c82acd8e7f80e6e1f2e825fbee19a1a4ea50293",
+        "dest-filename": "abcjs-YWJjanNAbnBtOjYuNi4z-7975552dcb.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -12389,9 +12410,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-        "sha512": "4c6c39c958b8b1a6a3b12120cf6e60ace6c61c451a0eb9e2c2f036ab0482d3ad0a7ea18f760961bcf300da53c8a31b373d0208b63da26a0df97ce35c42a81469",
-        "dest-filename": "adm-zip-YWRtLXppcEBucG06MC41LjE2-e167d1b9e6.tgz",
+        "url": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+        "sha512": "f94b7c77d2cbab012f1c7265d7e3c81eaa320f116054df38ec94d53372338b7c470d63c4e14b73cd7cac31942ceb80cc72b25f05e4bfba810fe000f71d01e741",
+        "dest-filename": "adm-zip-YWRtLXppcEBucG06MC41LjE3-035ea96d04.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -12494,6 +12515,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+        "sha512": "7e0171ec77e8abad32b4ad9cec386717c8c8bf362038cc5fba08cb3923078cb20f81e9ea6bb4bba1a6a001352af7d995e8862f376b51982d309d3617ea23db33",
+        "dest-filename": "ajv-YWp2QG5wbTo2LjE1LjA=-0916dda09c.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
         "sha512": "b11bb592970ef722ed63104abea7d37a1f4acd91303b7493c97d474fee02683cc2e87a5319884884f2338fd5ee294eca603c2769e87985c3b08f2d50b89cc13c",
         "dest-filename": "ajv-YWp2QG5wbTo4LjEyLjA=-b406f3b79b.tgz",
@@ -12501,9 +12529,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/ajv/-/ajv-8.8.2.tgz",
-        "sha512": "c7d56e5fe47f8dc163d431e8fdf0a9f7d7ac8060d688710dacac5a08436e0b1a68302980b7f08e086543c00ee495e1291332630e7be1df21a83ae2eed03b6597",
-        "dest-filename": "ajv-YWp2QG5wbTo4LjguMg==-2ef3c2bb34.tgz",
+        "url": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+        "sha512": "4e16e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118",
+        "dest-filename": "ajv-YWp2QG5wbTo4LjIwLjA=-5ce59c0537.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -12550,13 +12578,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-        "sha512": "2685f46a919b1da50904d97ac85fa9e89005619ebaebf86108628de6df501636c940a514fe0f0c35b1436ef7eb80a5ef23542966994f3a7c08a3df655ff00098",
-        "dest-filename": "ansi-colors-YW5zaS1jb2xvcnNAbnBtOjQuMS4x-e862fddd0a.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz",
         "sha512": "7735bd907c47d35d6e06c89d4d7775e095e0cf27bf60b6f62f378a6786ec825fca9f0c7c02d6d2164906c5a81d34ea21d0396a1c299f8848d62816aa8ce6a757",
         "dest-filename": "ansi-escape-sequences-YW5zaS1lc2NhcGUtc2VxdWVuY2VzQG5wbTo0LjEuMA==-a3b1c4073e.tgz",
@@ -12574,13 +12595,6 @@
         "url": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
         "sha512": "80a5e3e402eb29640bb181bd8e54d1991ff12a5bb11d5f99f501303488027ccd7fbb03cc0aecd55678799b04ddf8eb8165cc1220c6eab2c356466d65139d5069",
         "dest-filename": "ansi-escapes-YW5zaS1lc2NhcGVzQG5wbTo0LjMuMg==-8661034456.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-        "sha512": "e4614c557f07a84fd307e16e0491ae3b95c6d16aec03aa6d52aa0e0da4ff9fd9a651a64592a9c1b9e07895ea860429ab5079c29c2e0f0994c277413b410f376c",
-        "dest-filename": "ansi-escapes-YW5zaS1lc2NhcGVzQG5wbTo1LjAuMA==-cbfb95f9f6.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -12704,9 +12718,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
-        "sha512": "b8c823a33c924bc69d65961e3e9696b3c73107dfe47739a95fa4a0259fb06f3d4ae5e624e503180d525a64a871c881d47679c991f47b495812b601fb2e4194ca",
-        "dest-filename": "any-base-YW55LWJhc2VAbnBtOjEuMS4w-c1fd040de5.tgz",
+        "url": "https://registry.npmjs.org/ansis/-/ansis-3.17.0.tgz",
+        "sha512": "d2a594825b7d244a8b16bdf0d48d696eb0a19f582b85a880476a1c5f53cffdf9519b182dc13ccf1451677c8943e9a30e2d06604ae091962743ef496fc7cca1ce",
+        "dest-filename": "ansis-YW5zaXNAbnBtOjMuMTcuMA==-6fd6bc4d11.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -12732,16 +12746,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
-        "sha512": "c70746d0524f40c7b4334500e13cf4cc407cac1253440e5ae3be996b002a88190cbf5e8644ae71a574e13a331a10e16767acda6de8e31b827775ad125c6eb728",
-        "dest-filename": "app-builder-bin-YXBwLWJ1aWxkZXItYmluQG5wbTo0LjAuMA==-5d401b2670.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-24.13.3.tgz",
-        "sha512": "140cd7e88062b763ce5d81a74c24fc60714efe5af901aa40208eb3ce140edd1c387040ce80afadd7184b739b4d70a9627131e5a3dcf12309d8097f57d832e48a",
-        "dest-filename": "app-builder-lib-YXBwLWJ1aWxkZXItbGliQG5wbToyNC4xMy4z-4379dc87e0.tgz",
+        "url": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.6.tgz",
+        "sha512": "94de819623492e74b6aee05d61dd63d6bcdddb29786702aac93b40c15ce722491a74e47d705bd1cffb4d43a9ddf36e00a1b9c564a85c745ae92060e7af43d14a",
+        "dest-filename": "app-builder-lib-YXBwLWJ1aWxkZXItbGliQG5wbToyNi4xNS42-5970086976.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -13166,6 +13173,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+        "sha512": "4b6b3768ecad88a74545dba5c36a8f139d4cce3cd53a2b29a5c56fee354547e2b0d24c70bc5ac371803487b35da9b9a3d0790c2176166a88fb7e58bc920c757a",
+        "dest-filename": "asn1js-YXNuMWpzQG5wbTozLjAuMTA=-9cfbca89b1.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.7.tgz",
         "sha512": "b8bbeae8a26ed38aa840cea0bc17ca163961e86974bce290b91e5c24c0c74249b07cc39078ddc5dd21c2bfd48d6122fe091a07bce1857e5943955cf4dc6423bd",
         "dest-filename": "asn1js-YXNuMWpzQG5wbTozLjAuNw==-1ae92cc682.tgz",
@@ -13411,9 +13425,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
-        "sha512": "04048e83e6303b60bedf8eb1dcb64e7a8a2f4c8a13ad1a84b2a31ae9f99f015d0ff94f6616bf4db32384a6262f1636dceb834cad2b30855e7459d5f375bfd9e4",
-        "dest-filename": "axe-core-YXhlLWNvcmVAbnBtOjQuMTEuMQ==-bbc8e89592.tgz",
+        "url": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+        "sha512": "9477badb3bdb4c1e5e100054562fc0c1587464a63dacc3038669be79ecaeb9441b437f89f9f38d550399ca3f8376bbc3e01637dee6278b2449e142486922807f",
+        "dest-filename": "aws4-YXdzNEBucG06MS4xMy4y-290b9f84fa.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+        "sha512": "2ae9d2371f93569900c3fe942df867c7e1d645e723a991933b2aae02858760b45274ad6d07922171ed595be518ddf8f7ddb6001563eeed6fc64529a6ac21aec4",
+        "dest-filename": "axe-core-YXhlLWNvcmVAbnBtOjQuMTEuNA==-49095daa42.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -13439,9 +13460,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-        "sha512": "733e2eafb55bd314b8fca50dd2d3d67b8e1eab1ac8bb7d667be7db6a78378a388db1c135dbd3cece2a49240eb39e2ab60bf67ab090a33229a34bc2dcfc602cf1",
-        "dest-filename": "axios-YXhpb3NAbnBtOjEuMTMuNQ==-db726d0990.tgz",
+        "url": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+        "sha512": "de74ef165be99fd66efd190752ab5cefff9a978529456e5acfbd5aa79cdc729e9ef1101813384c4de717f03cf5c160d8acfa54a01d4701010610012f52bed2f6",
+        "dest-filename": "axios-YXhpb3NAbnBtOjEuMTguMQ==-c4cdced3ee.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -13698,9 +13719,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.10.tgz",
-        "sha512": "c13b7b3ce6af2c5ca92dc3d6fee0b9bfccbe9ad40a0c98b218bcd80a3aabf6dc7441cdef0977032a4d62085223ffef88cb90968614df9446bb56f54f3567827f",
-        "dest-filename": "babel-preset-expo-YmFiZWwtcHJlc2V0LWV4cG9AbnBtOjU0LjAuMTA=-210493e87f.tgz",
+        "url": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-54.0.12.tgz",
+        "sha512": "eb179291d6a2c6642159260beed7cbbb4a4e4b4058fbc7edc2674d487b691054a2ceb5d86640a393f07a0f1afeea7c0d462862c4c712d1a065592d70943977a7",
+        "dest-filename": "babel-preset-expo-YmFiZWwtcHJlc2V0LWV4cG9AbnBtOjU0LjAuMTI=-f2a3d4b258.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -13743,6 +13764,55 @@
         "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
         "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
         "dest-filename": "balanced-match-YmFsYW5jZWQtbWF0Y2hAbnBtOjEuMC4y-9706c088a2.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+        "sha512": "04bae011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c",
+        "dest-filename": "balanced-match-YmFsYW5jZWQtbWF0Y2hAbnBtOjQuMC40-fb07bb66a0.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+        "sha512": "674a071070050d991f7cdf10737f733598d094c0e43c9472cb2662794d551fbbbc7394bea876764bc8b174a200c448df1ceec52715e625682d78e82155a9c8b2",
+        "dest-filename": "bare-events-YmFyZS1ldmVudHNAbnBtOjIuOS4x-0692be1767.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+        "sha512": "693bcc1545a40668f32ad1103031860cd17c6e47e90f93756ff142c2dec0df0ad4e2dd68fdeffce56ce496e87a2653830a3a9511260291009d4d7a99f46ed516",
+        "dest-filename": "bare-fs-YmFyZS1mc0BucG06NC43LjI=-a0fafaf46e.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+        "sha512": "e8ce578dc9ecca040d3cc08c3d748adfbf71ac916267f00430d0661449905bc77fefcf554004efae2ca2e6bd076132fd4e4436eab9f79207531b76a2b1bad791",
+        "dest-filename": "bare-os-YmFyZS1vc0BucG06My45LjE=-2a106aca9e.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+        "sha512": "8218f60d22bfd9ef7d6b56a74d53c25789b860862dadb5e17cced5dc3ed764b393b326e7632689968ca61aab2c41cf25fe8af45280f246d35092690417fcac81",
+        "dest-filename": "bare-path-YmFyZS1wYXRoQG5wbTozLjAuMQ==-278e4bee8c.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+        "sha512": "569d1c9e3632ac40b8c21613ca643e6198baa41a5f8880993b771f446f2ccbaed93567bde75babbf5c78796d4128d9e0c3753eddf3d86f9250bc76c2b711fb3b",
+        "dest-filename": "bare-stream-YmFyZS1zdHJlYW1AbnBtOjIuMTMuMQ==-50aa90a700.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.4.tgz",
+        "sha512": "cdb4098b661051edd2ad7d7d4c8b50f03a0f8fd1358b9aeb744f621d5e0f85489fd46a1d35149ef3995abd519b994ecfe0cf39efd1108b86a4185ba10804d669",
+        "dest-filename": "bare-url-YmFyZS11cmxAbnBtOjIuNC40-c9c8fea552.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -13922,20 +13992,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/bl/-/bl-5.0.0.tgz",
-        "sha512": "f2fc45359d297e515f8b45970375905e58fa09a304c2c9a1eb723508da74abec16bfcb03d00471d4aa2f4907749761a4c2b3083b279dab4105d45c48f910992d",
-        "dest-filename": "bl-YmxAbnBtOjUuMC4w-fe2af4bf39.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
-        "sha512": "ec1d51b71f368639d20f83c62c08d559e607ded1c07155260a187ce5ade596d2909ba16b7ac5e1f44ad0a3aa00bfa0aac6db5ccc2dff90483c498e4d96e3ee53",
-        "dest-filename": "bluebird-lst-Ymx1ZWJpcmQtbHN0QG5wbToxLjAuOQ==-9c06c4b253.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
         "sha512": "5e9363e860d0cdd7d6fabd969e7ef189201ded33378f39311970464ed58ab925efd71515f9acf1026f2375664dd3a413424fb63765c1f6344392f6e6426711b6",
         "dest-filename": "bluebird-Ymx1ZWJpcmRAbnBtOjMuNy4y-007c7bad22.tgz",
@@ -14034,13 +14090,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/boxen/-/boxen-7.1.0.tgz",
-        "sha512": "49c1bc083a3c763ecc72a099e61cf8748069db4c63e2e9d0da55c80daedf7fa45c644942a6e373bad770cca56f46291f3639bb0850254771c91dca07903384c5",
-        "dest-filename": "boxen-Ym94ZW5AbnBtOjcuMS4w-a9a631b5ed.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/boxen/-/boxen-7.1.1.tgz",
         "sha512": "da10a08c498ff182d6435df49f615eac6bfbad8a5f0669e6a7d532d8b7b5be07ba5f781921f4a61333f94130c4945c5cbd57179449fc02ae8c53f3d9ca020ea2",
         "dest-filename": "boxen-Ym94ZW5AbnBtOjcuMS4x-a21d514435.tgz",
@@ -14090,6 +14139,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+        "sha512": "30257f7d82446eac7af1a139f24bf6700fe48a4cb51bcbeec77391ebf8db4be8c831effa7c959ad034f3254eddaa28ce598c078b5b76f4595f608f6ecadaa5a4",
+        "dest-filename": "brace-expansion-YnJhY2UtZXhwYW5zaW9uQG5wbToyLjAuMw==-e9dd66caaf.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+        "sha512": "559ce72e0b70867f8c69cb7db5f8b0c7ae1f03d7ab1c7fcc0971147c1ff46d7ffa173ea7cb91064d7625b4ca1caa0e31140419b673b70c75965e2f118ae37b71",
+        "dest-filename": "brace-expansion-YnJhY2UtZXhwYW5zaW9uQG5wbTo1LjAuNQ==-f259b2ddf0.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
         "sha512": "68d75b9e3f4ff0f8dd5d4e326da58b2b6205de373f1280d86c2ec06b35bab68dd346c7d7c6c702f545ce07988388442b93221b5a9d922d075ae3e4006bb9dcdf",
         "dest-filename": "braces-YnJhY2VzQG5wbToyLjMuMg==-7c0f0d9625.tgz",
@@ -14100,13 +14163,6 @@
         "url": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
         "sha512": "6fcba6f8bd51cccdd60d2cef866ea0233d727d36c1b7a61395c10a02fb26a82659170e3acfadba9558fd8f5c843d6df71f91fe94142964c3f593c97eefc1dad0",
         "dest-filename": "braces-YnJhY2VzQG5wbTozLjAuMg==-966b1fb48d.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-        "sha512": "c906d780efce499543d88b222e5ae8fbb1dfe90d7c109aca484b1da0ccca78f29772dde0bc3f282dc390748cc6ba9af9163f840def203bf9717350737cca71bc",
-        "dest-filename": "braces-YnJhY2VzQG5wbTozLjAuMw==-fad11a0d46.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -14335,13 +14391,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.4.tgz",
-        "sha512": "ba9a7e6e22a937f5d930b8a6eda82e5325bcb34154a43bceb4aeac6da9cc14300c073a470ea761815626eb373d1c9ea75a8eeed8bc64eb48b633a25ddda88dac",
-        "dest-filename": "builder-util-runtime-YnVpbGRlci11dGlsLXJ1bnRpbWVAbnBtOjkuMi40-6b4b6518f8.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.4.0.tgz",
         "sha512": "a2692968a6eeb4f62a0b49f02c4786ab9e34c4d0f560f85f573c13e82172085cf184d0edfd7f9fca4af5ed8a378f18aec08df36809d8ff5b4a16844df8578786",
         "dest-filename": "builder-util-runtime-YnVpbGRlci11dGlsLXJ1bnRpbWVAbnBtOjkuNC4w-20fb7321b5.tgz",
@@ -14349,9 +14398,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/builder-util/-/builder-util-24.13.1.tgz",
-        "sha512": "3616c24889edaee3434ce548f5f757cf476285aa97d98b84d43eb364caf0884af31f810b64713a99d881e34c04819369ac389af8582144580aa00a8c65146348",
-        "dest-filename": "builder-util-YnVpbGRlci11dGlsQG5wbToyNC4xMy4x-e63836c920.tgz",
+        "url": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+        "sha512": "83f911e76d208801589125d3cdc985de4a90abbc22f05e8de92cde0e066ba9304df951dd9a058ec93743d720fb0004c321dff25cbbee3f7e02c56e3afc1c0277",
+        "dest-filename": "builder-util-runtime-YnVpbGRlci11dGlsLXJ1bnRpbWVAbnBtOjkuNy4w-ec27cdce62.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+        "sha512": "ab6867ecc6e8da714d9157a43e21c5c7a35fa37854466112ded7c19fe9393eac65d919263f7406a995211ffabd3dc87fe06d3935184f8c39558f53bcab84f1bf",
+        "dest-filename": "builder-util-YnVpbGRlci11dGlsQG5wbToyNi4xNS4z-5736dd5594.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -14450,13 +14506,6 @@
         "url": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
         "sha512": "555758cd7127f9c9db5e91605ace614d3ece49c7a01d598b849211f147ea9378850fa03a8f98925f52ae0537cd12fe2d749584d8fcc0e88545b5c2c2edf37dc1",
         "dest-filename": "cacache-Y2FjYWNoZUBucG06MTUuMy4w-1432d84f3f.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
-        "sha512": "ffe126723f43017c57e1cc252e6448f5cd7ae91b8bdf0df4ce9e11ec9a22bf67104ed4ed03e8deb820231f76651a7612ded284352aca840cd554ff46572cde61",
-        "dest-filename": "cacache-Y2FjYWNoZUBucG06MTYuMS4z-a14524d90e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -15077,6 +15126,20 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
+        "sha512": "59dcb6220bbc39c069236a5978f679a168cf0b7f2d983571e562945cac252d8900d28ce8f39b0bb0bbe405b067fec65a482305386649d787ef5bdb79fddee474",
+        "dest-filename": "ci-info-Y2ktaW5mb0BucG06NC4zLjE=-9dc952bef6.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+        "sha512": "efb3d2c1eadc09953615ce2c5fde1e17c93c3f1b5ee890302f8fc80992c58c92ea7a0b3b902b80b2aaa3ffbd0d405e93bc3a6016392e6d0076156d9965d76f42",
+        "dest-filename": "ci-info-Y2ktaW5mb0BucG06NC40LjA=-dfded0c630.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
         "sha512": "2a486de727ba6469b0bf8d2e503673b5ac93d9384b4067e78ff4fbd4dfd7cde65ea379dff1fa325bbcc64ec3d8904c9ade6e5fddc032a47faa7bb60eaccd54d9",
         "dest-filename": "cipher-base-Y2lwaGVyLWJhc2VAbnBtOjEuMC40-3d5d6652ca.tgz",
@@ -15094,6 +15157,13 @@
         "url": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
         "sha512": "a8e84f6bf163eece9363c1fc7ac1aee5036930c431cfbf61faeaf3acd60dea69fef419f194319fe5067e5de083b314a33eab12479e973993899a97aeae72cc7a",
         "dest-filename": "class-utils-Y2xhc3MtdXRpbHNAbnBtOjAuMy42-b236d9deb6.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+        "sha512": "2616544fb245710cbf1335bad3993f92d1ed9dca28f6f9f25bfd86b29358c0594dd42fd69a3b95ff1b52d387bd48e90bdac4ddc3454067650609c43d951ea9eb",
+        "dest-filename": "classcat-Y2xhc3NjYXRAbnBtOjUuMC41-19bdeb99b8.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -15168,13 +15238,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-        "sha512": "546b6532edf1ff80ceb4853012445ecf1519da505a70d2421dab21d0dd167990c14beed4c75766dd75808166312c914c31d39e5cc1d7a2bb2110585b31219e96",
-        "dest-filename": "cli-cursor-Y2xpLWN1cnNvckBucG06NC4wLjA=-ab3f3ea207.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
         "sha512": "6828f83b9c0acacce33260d3e2d663f77931cb274dfcae733d64827baff4015fc0035a6a7b9641230d1ad997cf415ee52f9ff26f91ec52b789e94140175b4443",
         "dest-filename": "cli-cursor-Y2xpLWN1cnNvckBucG06NS4wLjA=-1eb9a3f878.tgz",
@@ -15185,13 +15248,6 @@
         "url": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.6.1.tgz",
         "sha512": "c7fe5f5a618c9db29001a37037e519955efda812ccf4916726e274de0222e7086ba1bd31574a1f3551f2f4387019db0c25073638abf4a0698bcef6aabc056ffa",
         "dest-filename": "cli-spinners-Y2xpLXNwaW5uZXJzQG5wbToyLjYuMQ==-3e2dc5df72.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-        "sha512": "aaede937c637a87360136005c1e72207521f327999fdfb0d4c413e34e16398607617feeb2e19e1ce9a6fa429cde05a2fb4fdba93c947cb2f69b446cdc1614bcf",
-        "dest-filename": "cli-spinners-Y2xpLXNwaW5uZXJzQG5wbToyLjcuMA==-c382ee8b0d.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -15546,13 +15602,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/comlink/-/comlink-4.3.1.tgz",
-        "sha512": "f986e151d36ba4166080100759c81030b3cb1f5283177c09a5eaab08a89e590f112fb6ad9a0b204d0928d571012ba3ec79c7e8a56367b68a49f81c981b595168",
-        "dest-filename": "comlink-Y29tbGlua0BucG06NC4zLjE=-538a3d64e9.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
         "sha512": "187b8344ed764b2a6ed9c57bd1dd5d900d845265c7827b6bcdba6f381f90cbee3dca935f1a0150202d9f8615db9f2ac94729c3080011b13ecebb433a862ae97f",
         "dest-filename": "comma-separated-tokens-Y29tbWEtc2VwYXJhdGVkLXRva2Vuc0BucG06MS4wLjg=-0adcb07174.tgz",
@@ -15801,13 +15850,6 @@
         "url": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
         "sha512": "aa3f9ff003c04571eb33486b6aa5d86f6fdb395495e0fbc9425359fc3563d10ae634cdaad9eba2ce47ae55c910e7b27e5b49911fa1ef8be939d0ce09ba5d9545",
         "dest-filename": "config-chain-Y29uZmlnLWNoYWluQG5wbToxLjEuMTM=-83d22cabf7.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.4.tgz",
-        "sha512": "70a496d017eb49a0149f1a60be95cf2da696fee9a0e1baa0e24dc63b526a9517e9c7e7795b41835f39c23245a8b4941e939326cf53095428509f3dc855a78c65",
-        "dest-filename": "config-file-ts-Y29uZmlnLWZpbGUtdHNAbnBtOjAuMi40-9094f31c6c.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -16113,13 +16155,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
-        "sha512": "5cce111646b9f71013c89bff712dcedca9a5ef68505d478646eb9398c605c70cdcf7fec2f0e61368847f262f98b7c0d7cec14b3616add79704fc93f5e47ac283",
-        "dest-filename": "core-js-pure-Y29yZS1qcy1wdXJlQG5wbTozLjQ5LjA=-ae769f3df1.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/core-js/-/core-js-3.33.1.tgz",
         "sha512": "a954aadecf9de3e1aca8dd2d791089b4cead744117c96c63cdb855ac21e6052e594ccd054b630e4b40f5ddd5170160d437a6be94723f375845f58b73ea22e5f5",
         "dest-filename": "core-js-Y29yZS1qc0BucG06My4zMy4x-66a00c765b.tgz",
@@ -16214,13 +16249,6 @@
         "url": "https://registry.npmjs.org/coveralls/-/coveralls-3.1.1.tgz",
         "sha512": "f9dc671b63479dc483d4daea6d2337767fe5139ecee907ff9287bdf88edcfb0ce4a91984bdca7492025dc4a227cd8ce42022a414c66c5f755cb77fbeb6c17dc3",
         "dest-filename": "coveralls-Y292ZXJhbGxzQG5wbTozLjEuMQ==-2508710c0b.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
-        "sha512": "897de67e0713308ab764a2c8b151406efefe31cd7493169b00641bf07be3035a374f53c8629adb6a443ae5ddc8fb61c61edea748a90cf4f62382824ed8a70505",
-        "dest-filename": "crc-Y3JjQG5wbTozLjguMA==-3a43061e69.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -17121,9 +17149,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-        "sha512": "b7911c2d54ba40f04da8cdb3f1f6a493f34a7a5f97cec860b7c1452809feab0943d69cd95b18749d50abbc52bb6436fa5ee719785f73f02ec20564d121502903",
-        "dest-filename": "dayjs-ZGF5anNAbnBtOjEuMTEuMTk=-185b820d68.tgz",
+        "url": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+        "sha512": "f7c213f8739a8408ac89bcffca329bcee381c1872327b0422cfcc04721e2c84066473e1f6ad17e28f26ccc41d7b06623506db7e1a1ff70e8d6d70c136ca51994",
+        "dest-filename": "dayjs-ZGF5anNAbnBtOjEuMTEuMjE=-dd16f9f270.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -17814,6 +17842,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+        "sha512": "b2fb5c7694bc0a0272a808c44085dd6f73a3845555623cc600f3bc5860a645bae697ae123f0fe3243e06a04f7c691eebdb90345dc82b2b7174db2c3d47fbe143",
+        "dest-filename": "diff-ZGlmZkBucG06OS4wLjA=-f8b5e38a6a.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
         "sha512": "92a6a0fcd97e7f71b0c8adb97e150c623f350543ab67d22e26c8c870313989c34cf452470159b755c503c5d2cfa10b53b94ca55a6e992249d8270c1a3f1b14ce",
         "dest-filename": "diffie-hellman-ZGlmZmllLWhlbGxtYW5AbnBtOjUuMC4z-2ff28231f9.tgz",
@@ -17828,9 +17863,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dir-compare/-/dir-compare-3.3.0.tgz",
-        "sha512": "27bfdeb775a51940b18dd9c3dc7000cd0ea7b2773458be830fb59cc096fb737f621f5f8059f83ef4eab324d688e8f901c01be6d6685934bf6263f9d18995e53e",
-        "dest-filename": "dir-compare-ZGlyLWNvbXBhcmVAbnBtOjMuMy4w-4e4ca87564.tgz",
+        "url": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+        "sha512": "db130298ea0cadd4083c776c4dac0409d34fc2554507dcc6733de4ba19813ba537a14f94423b2e7b48bc6b22caa6005c9be85c5cf31548650df5dfa9bc9ebe55",
+        "dest-filename": "dir-compare-ZGlyLWNvbXBhcmVAbnBtOjQuMi4w-e88cbe5021.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -17856,16 +17891,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-24.13.3.tgz",
-        "sha512": "adc25490c7e72697c26e866838e3dfe0bdbd4d1b4489e1cd39e01b60f58fc65681c3f67544aad103ce9d388f6bc1a238b5049cfd10fcdb34cd1e9adf5075eca1",
-        "dest-filename": "dmg-builder-ZG1nLWJ1aWxkZXJAbnBtOjI0LjEzLjM=-091914493a.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
-        "sha512": "65dce6ab02a6102396269a9e7e5a02e4e272d7e599041b1ee7e311f3ccfd83d667e1563e598524032a239a1cc97241f961b6d919c608b86024639fd8b3938cd9",
-        "dest-filename": "dmg-license-ZG1nLWxpY2Vuc2VAbnBtOjEuMC4xMQ==-10.tgz",
+        "url": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.6.tgz",
+        "sha512": "9ebe6f431121334444a26a75aa21db73a57df72adf059cbec14539e955c00df48e94b8fc3dd2eab078917bb6fe15ba8a7ac8b2bf86b1fa4d465701a89d82ae0a",
+        "dest-filename": "dmg-builder-ZG1nLWJ1aWxkZXJAbnBtOjI2LjE1LjY=-3c87682660.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -17887,13 +17915,6 @@
         "url": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
         "sha512": "df999292ee195cad2f7c2b87103030b79e5d8368cd6a31d9d6876f17ef124abf3612c658e109977ee5aca3ca0477ccd185539b48dd7c68cd028d2768057ef323",
         "dest-filename": "doctrine-ZG9jdHJpbmVAbnBtOjIuMS4w-555684f77e.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-        "sha512": "c92f90e62de105fec6064778286f1aede04d3563462d3684c306165228c860cef3ae56033340455c78e33d6956675460ed469d7597880e68bd8c5dc79aa890db",
-        "dest-filename": "doctrine-ZG9jdHJpbmVAbnBtOjMuMC4w-b4b28f1df5.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18003,9 +18024,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.1.tgz",
-        "sha512": "aa47422b32cdb6b80f14fd55a3ef7c151cc99c14467b87dfc8279af48c070757f2c4f39e3531e92ca606778524f71bcda07d19a0e8f0671369b72330aab21dd5",
-        "dest-filename": "dompurify-ZG9tcHVyaWZ5QG5wbTozLjMuMQ==-f71cca489e.tgz",
+        "url": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+        "sha512": "da30710c9638451d3ab50372e30e459451fb91fc6c41996e7ddd2c6eff9c85f1c2c5e270ac5c366da503b12c2f048483e0ae110db7743d37f2dee357b11eac88",
+        "dest-filename": "dompurify-ZG9tcHVyaWZ5QG5wbTozLjQuNw==-7432e2a2fe.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18066,9 +18087,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
-        "sha512": "617425d4349ae3f3d0c917e0aefe9aa0d8e16aca7fa78aacf458c9e2ae1c424fbc9b8afa938652884cb2b4a1bc7fc5bd822f16b10b4839b36629dfad33335398",
-        "dest-filename": "dotenv-expand-ZG90ZW52LWV4cGFuZEBucG06NS4xLjA=-d52af2a6e4.tgz",
+        "url": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+        "sha512": "cc81f09993d1b21b02769303c95b2a1a68323f4c93f060205d49e4740a098acc6f7f7de4ef23ba3aea0a99c4c6b973d64ac9bc3a1f3c9d989c44b03d634ad478",
+        "dest-filename": "dotenv-expand-ZG90ZW52LWV4cGFuZEBucG06MTEuMC43-1cd981e2b9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18080,16 +18101,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
-        "sha512": "255527b7e0d4233bbced30016e13e635f55d043b75f012ce5a33141493128bf42a83b35362d69b6ef48d246389eda7db46ebfd0ff967822cc7b4fed0c8b43ef7",
-        "dest-filename": "dotenv-ZG90ZW52QG5wbToxNy4yLjM=-f8b78626eb.tgz",
+        "url": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+        "sha512": "b81ab87a05874dc4eddf76bbdafa521b4cf71e73ee225e8da98713aca120d9ace81329768695b4cea971cacab6a4af47943207c87c9a91e61a627480c1df1ba3",
+        "dest-filename": "dotenv-ZG90ZW52QG5wbToxNi42LjE=-1d18971443.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
-        "sha512": "23d3afbeb1e9e2920046fe3ec7d8ae7b0ad6c9c5fa09c66da00bb55ebccfc5ce54ca03095c9658981b329e4bbc224ac9c20ca91390c63630cf98f4610c2a6d52",
-        "dest-filename": "dotenv-ZG90ZW52QG5wbTo5LjAuMg==-8a31ab90b0.tgz",
+        "url": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+        "sha512": "9c8e14dd3a2db4a01c003f4b2ee77809bedbd90ced40c5047c76ef8531f4f5ba974f19d289ef169e33c02d5fd6302ac967a515fea1c9e8bd373aa3b72dc75867",
+        "dest-filename": "dotenv-ZG90ZW52QG5wbToxNy40LjI=-ca1b6f54d5.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18178,16 +18199,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-24.13.3.tgz",
-        "sha512": "c994a05477ede5d355968df5aa62407b80552907c5770a51c3bb05a758908250d10830faaf6db37d126e66586d079829f451d4c42304a161aad744a40a730022",
-        "dest-filename": "electron-builder-ZWxlY3Ryb24tYnVpbGRlckBucG06MjQuMTMuMw==-d210e787cd.tgz",
+        "url": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.6.tgz",
+        "sha512": "8f1947463a98ae54e02d5a3f6a80021a98a48b740562ff2ce1fd9d8eca9a11bc13059f4f71304ad374e3fc731aeb992213485d671c5b65d995168db67a8bb6c0",
+        "dest-filename": "electron-builder-ZWxlY3Ryb24tYnVpbGRlckBucG06MjYuMTUuNg==-80a91eef12.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-24.13.1.tgz",
-        "sha512": "d9981d12a27c7bd0f5ec7c29e4b12ae662d03e3a94de5bff2002ef829fb85bc55e361af27c68581100bf3e00cf32b9d6529fa5eb43aee5224bb2efa4e26850f0",
-        "dest-filename": "electron-publish-ZWxlY3Ryb24tcHVibGlzaEBucG06MjQuMTMuMQ==-60133b51bf.tgz",
+        "url": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+        "sha512": "83fd9b9fc6136af63872e4b917e8ce4bbce665b5d7055f0a67cc8729f26314fa0ab7306aae909d34fc41777b6a741c0fec155dd251b37fb064dacd0a7ac599e1",
+        "dest-filename": "electron-publish-ZWxlY3Ryb24tcHVibGlzaEBucG06MjYuMTUuMw==-785bf60cdf.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18269,9 +18290,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/electron/-/electron-40.8.3.tgz",
-        "sha512": "307e8b2b8c4ce955669adcf49d113415ef25da34ca4984ef1f5b7465f6cd2f0de8e9d9410954d1a9085aeae2fc650568332ef82722e0b86c0aedd53bac228887",
-        "dest-filename": "electron-ZWxlY3Ryb25AbnBtOjQwLjguMw==-6d53f8a359.tgz",
+        "url": "https://registry.npmjs.org/electron/-/electron-42.3.0.tgz",
+        "sha512": "f5988b7515e4f960f15b53a0214cfc276ac84394d853da3adbd8023a3538f10ddd4223a6ca6ee8b16b07e546ecfc9878bae14b9fa9ba4810f6ae64572c03f3f6",
+        "dest-filename": "electron-ZWxlY3Ryb25AbnBtOjQyLjMuMA==-969c82badc.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18430,13 +18451,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-        "sha512": "ca33673ebdf5e7f1634b8cc8b14c5882e6143cfd9ed4d2b877b13b64e2e2c9809c6c50624ccc880fedb0be6db0ebea59fe874c03b71192386c3db96dc013ab2e",
-        "dest-filename": "enquirer-ZW5xdWlyZXJAbnBtOjIuMy42-751d14f037.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
         "sha512": "a7dda27f9373eb5f48d30f9a909acb647d0c5f43dbe435f7f573b0413b5749d41039a607d374b5b88429e2684e66d017af1ab85623baed84e22c1a36eb7f28f4",
         "dest-filename": "entities-ZW50aXRpZXNAbnBtOjIuMi4w-2c765221ee.tgz",
@@ -18489,6 +18503,13 @@
         "url": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
         "sha512": "fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
         "dest-filename": "env-paths-ZW52LXBhdGhzQG5wbToyLjIuMQ==-65b5df55a8.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+        "sha512": "76d2544dea73316dcb9bf34fc517f7c0fe3ae365168632f6b10c5cfb29b660c8f59bf1f6cc33503a57b369fce41f09fab0cb2d8c74f01ba89042c72d0d6fdbd4",
+        "dest-filename": "env-paths-ZW52LXBhdGhzQG5wbTozLjAuMA==-b2b0a0d0d9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18780,9 +18801,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-        "sha512": "1f23502269ec382ed7f4f30d68221e026e08482417b396b961ab135d59622afe2eb81a3574aac6d00fae412f0ce5e5e354c9cb8375a05da2afa6b1e514941f7f",
-        "dest-filename": "esbuild-ZXNidWlsZEBucG06MC4yNy4y-7f1229328b.tgz",
+        "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.5.tgz",
+        "sha512": "cdd4281c18ee0ea2acbd5e4e3da59a9ec3b07d243426cf948fd27ce5306f8f76c55b52635934942cc47075001cf2a31e21271b0a5c5e30ad2396bb41f658a784",
+        "dest-filename": "esbuild-ZXNidWlsZEBucG06MC4yNy41-bf31870a72.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18899,13 +18920,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint-formatter-codeframe/-/eslint-formatter-codeframe-7.32.1.tgz",
-        "sha512": "0caff7437fb354aabfecf7526220b13ebb0317c1ff4d130ae67f07ce2c2be08324332f9788a4b06e98f6e4075a8d2eb723f07ad529deb6ae2e56f5fd7ce2f202",
-        "dest-filename": "eslint-formatter-codeframe-ZXNsaW50LWZvcm1hdHRlci1jb2RlZnJhbWVAbnBtOjcuMzIuMQ==-bf5b313729.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
         "sha512": "828cd6d9b94c2c909e169070ba02d31b2bd58cda1ea35927a275c071ab42e9b8cf0598ada2dc5d59fec68a6af6e4de1cd0000ea3878e51f686f362093c3a6a08",
         "dest-filename": "eslint-import-resolver-node-ZXNsaW50LWltcG9ydC1yZXNvbHZlci1ub2RlQG5wbTowLjMuNw==-31c6dfbd34.tgz",
@@ -18920,9 +18934,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint-interactive/-/eslint-interactive-10.8.0.tgz",
-        "sha512": "6ec312af4355cb1a126ca6c0dd19fcb28e7e03dabe66ef31131888335f2e98f8eba9f04037c59c25fb16bdf73d3327e2aa7d96c0b0ccf6646095bc7e1e9fb3dd",
-        "dest-filename": "eslint-interactive-ZXNsaW50LWludGVyYWN0aXZlQG5wbToxMC44LjA=-67e8b5d8a2.tgz",
+        "url": "https://registry.npmjs.org/eslint-interactive/-/eslint-interactive-14.0.0.tgz",
+        "sha512": "175dd8e80d1987657732ba15684ff34a5591da1e73ff174b4ba39d93b84c765d6197b24530887f6440f8ae88290530309b3816f72937a35154fc5d8b2201eae7",
+        "dest-filename": "eslint-interactive-ZXNsaW50LWludGVyYWN0aXZlQG5wbToxNC4wLjA=-94635130c3.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -18997,9 +19011,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz",
-        "sha512": "4084fb147edf36677d9f8b1eec514a1dbb0b286422c3cf390ece98fecc4a80267a9dab700ac5dd80f3800e7615c4dd90ad1c1e17415959b27a4bb46c9fb965ba",
-        "dest-filename": "eslint-plugin-jest-ZXNsaW50LXBsdWdpbi1qZXN0QG5wbToyNy45LjA=-bca5434728.tgz",
+        "url": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
+        "sha512": "904378afd459975c5cb1be1aac6abcf4badc55d39414823f2520b0b533c9cafd7a983c263eb72e110c29c6a64778836f72c77ba0ae4efeb85d1a5c4545a670bd",
+        "dest-filename": "eslint-plugin-jest-ZXNsaW50LXBsdWdpbi1qZXN0QG5wbToyOS4xNS4y-c7bc4dc705.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19039,9 +19053,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.6.0.tgz",
-        "sha512": "e7b6737f0f06ebe1aaedac66d8f768de05bf471de1f58cb0827eb5b84ff77a54c239e3c41d5ae7da2e4275f07003504b2b44345aa72d2022144aa5d95bf569ad",
-        "dest-filename": "eslint-plugin-promise-ZXNsaW50LXBsdWdpbi1wcm9taXNlQG5wbTo2LjYuMA==-c2b5604efd.tgz",
+        "url": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+        "sha512": "eae1a2391d0836eba3afa3c442679248fec66c8309fde6c45d7884cdbfe73a3ebc2e49c7e4fc736ff01b662be6afa544e9391313cad38d12bdce12a92ba1ec44",
+        "dest-filename": "eslint-plugin-promise-ZXNsaW50LXBsdWdpbi1wcm9taXNlQG5wbTo3LjMuMA==-9f84fbd033.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19067,9 +19081,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-        "sha512": "74eb76d4eee54cc84333e5fd981e065fe0d9ad9b425093cbff095c4eac72af1e48bced0862d20b76dad0190a7ef27e52d20c1256639ff4d42b8cc3a07d066522",
-        "dest-filename": "eslint-scope-ZXNsaW50LXNjb3BlQG5wbTo3LjIuMg==-5c660fb905.tgz",
+        "url": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+        "sha512": "b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e",
+        "dest-filename": "eslint-scope-ZXNsaW50LXNjb3BlQG5wbTo4LjQuMA==-e8e611701f.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19130,9 +19144,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-        "sha512": "ca9a30c83c69552629917afd58fbf63c0642b4d8a9d4cbf92935b4482bab5efffd88ea5cac7f4f6aa504964b2a101ea90a1a87183442153cab6651a19cb34688",
-        "dest-filename": "eslint-ZXNsaW50QG5wbTo4LjU3LjE=-5504fa2487.tgz",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+        "sha512": "b43e34787c40df98743c421935e223907a034786238c9a77e1b88cd260efa6505efff981f881c2a870c657ba7117eecc9254ef8a085c08f3d90bbca75b28dd4c",
+        "dest-filename": "eslint-visitor-keys-ZXNsaW50LXZpc2l0b3Ita2V5c0BucG06NS4wLjE=-f9cc1a57b7.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+        "sha512": "5e83237413b07bf7ac56012f2e636c0f72111e49bb7db288506beb95e9682575198031e283620f58d9e2bfe1b08f2257cee36a56396be7ee32554663c9c2707d",
+        "dest-filename": "eslint-ZXNsaW50QG5wbTo5LjM5LjQ=-de95093d71.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19144,16 +19165,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/espree/-/espree-9.6.0.tgz",
-        "sha512": "d451ff222aee5d9f38b695259b4682504c0c9761e8e6296a561d15bd05f0f9bc80cffe1201c8b21cb95f98be5662ab2f0f7f28ca6754c01b2cd0bb4af26e2cfc",
-        "dest-filename": "espree-ZXNwcmVlQG5wbTo5LjYuMA==-870834c0ab.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-        "sha512": "a2bb99685923a2b4e9177da40d2239ffbe558b019e6608a7186cb636839283743d6e7c259e60e6e072e7925d111379fe9e30d7474dfb698d7ec79f19ff315dc1",
-        "dest-filename": "espree-ZXNwcmVlQG5wbTo5LjYuMQ==-255ab260f0.tgz",
+        "url": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+        "sha512": "8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261",
+        "dest-filename": "espree-ZXNwcmVlQG5wbToxMC40LjA=-9b355b32db.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19165,9 +19179,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-        "sha512": "6102d7529940c09802c9d43bf08309cb064271ea2a935a07d3538445d48025cffb5360329708e14822c312dab083cd7589d212ffd7c85391a31bbdc882328c56",
-        "dest-filename": "esquery-ZXNxdWVyeUBucG06MS41LjA=-e65fcdfc1e.tgz",
+        "url": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+        "sha512": "029e86d16430714fcb1ecbcbc0e3757c0417f59a7403663a63f709065f6bfc96d6f74672838ff36c6eb3cca6b639300b10b6ab60798abb41a1a4ce443beed3d2",
+        "dest-filename": "esquery-ZXNxdWVyeUBucG06MS43LjA=-4afaf30893.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19319,6 +19333,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+        "sha512": "2d47797aebdb30ba70385f26ea2bcf09b85079289854d6fc56cd1f43c4235e8d094e4107a73f29c5d41fd204ad96d68fa70d0271af1bdfd2b1bcaf5c7ca46203",
+        "dest-filename": "events-universal-ZXZlbnRzLXVuaXZlcnNhbEBucG06MS4wLjE=-71b2e6079b.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
         "sha512": "90472fbc2041c965c69d9cba254960029da00485237c2015e8fe93813d7f69a40a726b80102e0e65357523811640bcf6831670efa6adb95caf1e14f1be2d0597",
         "dest-filename": "events-ZXZlbnRzQG5wbToxLjEuMQ==-524355c436.tgz",
@@ -19417,9 +19438,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.12.tgz",
-        "sha512": "0ac5c50906f1d9f12548c9f49724dd448c8a9525ce6a5ea294b25dfb2799eb1682ec8f40202420b1c6399e3d10730800f8a6180821101019dd32c9a3eddace59",
-        "dest-filename": "expo-asset-ZXhwby1hc3NldEBucG06MTIuMC4xMg==-7034316d82.tgz",
+        "url": "https://registry.npmjs.org/expo-asset/-/expo-asset-12.0.13.tgz",
+        "sha512": "c7fa7b5af4149e49fa2b8ddbf5e2fa48f7aae559dfd44f010def5b0eb5abbccab3c94bc99d416f97e72d837d37e2cffe5077bb35eda9026734fb2cdb97c0ab0d",
+        "dest-filename": "expo-asset-ZXhwby1hc3NldEBucG06MTIuMC4xMw==-02ab81f36b.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19445,16 +19466,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.21.tgz",
-        "sha512": "b370e5ac3762b1c047b5a6ffe96d68b2b8c62fe0b66efa089cf243eec3b09b17c9e56a329efda873e173d7fc555da13f57b1c4ffec6b1c2fc7e39b6eea5673ce",
-        "dest-filename": "expo-file-system-ZXhwby1maWxlLXN5c3RlbUBucG06MTkuMC4yMQ==-00a2f13f81.tgz",
+        "url": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-19.0.24.tgz",
+        "sha512": "859b34360f9ca0d8f1ed827c30fc1f269a14d5246e97a399f4b672705ce8cd47a847e75e9dbcabf78e18acc3fd3559fe65fd6d742ee9d0ad3381a87767248e62",
+        "dest-filename": "expo-file-system-ZXhwby1maWxlLXN5c3RlbUBucG06MTkuMC4yNA==-fb855703a2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
-        "sha512": "81ad2aeb59f2e2cfe4af893c257f61547ebd7b155221f708735f7ea99ee0b7bd4caad9bbc72d9cea4c2c3d30b28415b6468e725d34fc11a64ea6e462df9ac76e",
-        "dest-filename": "expo-font-ZXhwby1mb250QG5wbToxNC4wLjEx-80acffecdb.tgz",
+        "url": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.12.tgz",
+        "sha512": "410cee9c4d8cc64e3902c0969b7b4aecea559636ed567283e7cab8fea9627aff9c6f27b520e76e527448743f8fec3c81badc35ec6f4c4d7efde6481a422cf985",
+        "dest-filename": "expo-font-ZXhwby1mb250QG5wbToxNC4wLjEy-dc1f465735.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19487,30 +19508,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.24.tgz",
-        "sha512": "4cffba1d3c212fba2b0efb33d95cdabb24255c97005b253700db19ec918be0342ef17699bff038d597216ed0182dfa33340d986b51f39a1c7ae615ebc8132369",
-        "dest-filename": "expo-modules-autolinking-ZXhwby1tb2R1bGVzLWF1dG9saW5raW5nQG5wbTozLjAuMjQ=-e3b77d2fa8.tgz",
+        "url": "https://registry.npmjs.org/expo-modules-autolinking/-/expo-modules-autolinking-3.0.26.tgz",
+        "sha512": "58e6ae77a50a835e9c8823a3f2b68a70c3a82853072d7288dbd536f72860bb595ff98ed5c49c8292d51c628e8033e71c67bccb0f5b9665d32d827a5ffbde4e5c",
+        "dest-filename": "expo-modules-autolinking-ZXhwby1tb2R1bGVzLWF1dG9saW5raW5nQG5wbTozLjAuMjY=-43a68f1a63.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.29.tgz",
-        "sha512": "2f38a97231aa93c82f92b3947fb3b699e8cd5ae80f91fde599df4692a2fd5ae37278dd9f4705340e7efb7b7654288de4eac23e0cdc2392ae0dbbd7cd37d592ed",
-        "dest-filename": "expo-modules-core-ZXhwby1tb2R1bGVzLWNvcmVAbnBtOjMuMC4yOQ==-db23a1c732.tgz",
+        "url": "https://registry.npmjs.org/expo-modules-core/-/expo-modules-core-3.0.30.tgz",
+        "sha512": "6ba22ba409ff25b9b0c62f4bfa13265caa4daa7914a6817b5873a99f4dab54bc9ac76274801d6fbc2544e6b3727699449ede3543a5b1430bdc3a365a22471252",
+        "dest-filename": "expo-modules-core-ZXhwby1tb2R1bGVzLWNvcmVAbnBtOjMuMC4zMA==-092155a0a9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.5.tgz",
-        "sha512": "20647ef9f9581fbd2b84bc9e5c5d0f8657b9ebf93871e7bced6790e266a64be32454054ff9d0e53877f69cdd3a67d6362a15341a9d64fb2eb52a482117b1dd84",
-        "dest-filename": "expo-server-ZXhwby1zZXJ2ZXJAbnBtOjEuMC41-42cda83d5b.tgz",
+        "url": "https://registry.npmjs.org/expo-server/-/expo-server-1.0.7.tgz",
+        "sha512": "99c9b230bde85dca85517531b5db422f53b4d33b4d236bfbe9df8c76789745480737121c1d9d39ce8f83a8168e393e8b4273e4e2f038607a9097b88651f45bde",
+        "dest-filename": "expo-server-ZXhwby1zZXJ2ZXJAbnBtOjEuMC43-fe8bfb25bf.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/expo/-/expo-54.0.32.tgz",
-        "sha512": "c8bf5e4f1890fd028a8205430163b908b8d497a212d253d8804bc2dd0338ab87f177aaecee4b370e76d7486554dca345a18ffb7113588a1bddd0b2983fe3025c",
-        "dest-filename": "expo-ZXhwb0BucG06NTQuMC4zMg==-78c9b88b98.tgz",
+        "url": "https://registry.npmjs.org/expo/-/expo-54.0.35.tgz",
+        "sha512": "13eb57a50c231a6e5f2bfbb06b9e69d17c7f92ea397570ca7d527de486ab81335ae4a885b76ea54935d76bd2a71db2381032f0143dfcff14ca66fccf4e519376",
+        "dest-filename": "expo-ZXhwb0BucG06NTQuMC4zNQ==-329dfd727e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19648,6 +19669,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+        "sha512": "fddf6c7e8b38cb1ce9c240e4b8dee4d92a852ad60d9824f381f129cfcdb1df820cf7fcdcf0a1b14285e0d6588d0bf8b3a5133f30176de38366c78d595aa93e15",
+        "dest-filename": "fast-fifo-ZmFzdC1maWZvQG5wbToxLjMuMg==-6bfcba3e4d.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
         "sha512": "8352ae4301ce64098e64cb81b477710ed8eef93d914fc8e0082f5a00db1ba5d8830d34a78e07ee56c20134a6d4789237a0a31113171f343b499783a16df7ccb3",
         "dest-filename": "fast-glob-ZmFzdC1nbG9iQG5wbToyLjIuNw==-9e7d4e4d99.tgz",
@@ -19704,9 +19732,37 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+        "sha512": "d238e32042fafb48da8379765d65a2cceeb8fda655b69886137b74660ab1bf40cfbb188c8ef077336e1f0b285950ee0aa262503e3dcb4d25270cfdc6a5dc02d2",
+        "dest-filename": "fast-string-truncated-width-ZmFzdC1zdHJpbmctdHJ1bmNhdGVkLXdpZHRoQG5wbTozLjAuMw==-3a1631e489.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+        "sha512": "817f0baed34423986af035547d140c6ebe65a5a4b89cc21657eed711b5e4d9bf24890222ce09e5af5d81e1d037644c77df4f337b43b843547e707b6cf24c9426",
+        "dest-filename": "fast-string-width-ZmFzdC1zdHJpbmctd2lkdGhAbnBtOjMuMC4y-5b9019769f.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+        "sha512": "8bbd0bc0659476e5eace270a5d6b21a28abeb162f52b7594539aca64d1bfd22ddad4e4a85f71ea847e566d6c139aa59fa2be2ead46a418f89141c95e4594f03a",
+        "dest-filename": "fast-uri-ZmFzdC11cmlAbnBtOjMuMS4z-7969a50a32.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/fast-url-parser/-/fast-url-parser-1.1.3.tgz",
         "sha512": "e6338255700360db9190a173349d1d0827b0b19898a34773f1035896390ea450baaf653838198ab6f9bf4ecba1e30d5861d0ea0dbdf56bc4d584127638929da9",
         "dest-filename": "fast-url-parser-ZmFzdC11cmwtcGFyc2VyQG5wbToxLjEuMw==-6d33f46ce9.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+        "sha512": "ec5d8597e4e34527a72ea954dd48d21f48b2aa8a6aa1922eede655a448ab3f68351ad59ad86fde704981760cf7d7e331afe10b725820eaca24a52148422674d9",
+        "dest-filename": "fast-wrap-ansi-ZmFzdC13cmFwLWFuc2lAbnBtOjAuMi4y-c72272e4ee.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19802,13 +19858,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-        "sha512": "704d6ab01fd5c32428cd9faad5d1b147c2c160d65ea1f84475434648c6d00f71b0da50335fd65bdee214e846dcfc59b28e8f405967e79f4014087aad7afb3ff2",
-        "dest-filename": "fd-slicer-ZmQtc2xpY2VyQG5wbToxLjEuMA==-db3e34fa48.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
         "sha512": "862168aa9c9971f366d72738bbca1609ff40d9ce03dd08c2ae4b37ce6a15295c69411ce63cd6abd615097011b64501ef11518337e266f356617952c040c2bafb",
         "dest-filename": "fdir-ZmRpckBucG06Ni40LjY=-c186ba387e.tgz",
@@ -19844,16 +19893,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-        "sha512": "c9a76e40544a2d760e1a0127e8065abbdd23de08123b28aa5d4d05f4965f79762135af899385feb38e40db38398e7b3cec60056b7e01066da45f0e17a4d71b76",
-        "dest-filename": "figures-ZmlndXJlc0BucG06My4yLjA=-a3bf94e001.tgz",
+        "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+        "sha512": "ec6a6cfd75b299b2e4d902d82b8373a4c3ab623321748c57b88bf2d9006c2c4ea58eea1d2af7645acfdca72249dc25485691f43a2d47be0d68bdb3332dd14106",
+        "dest-filename": "file-entry-cache-ZmlsZS1lbnRyeS1jYWNoZUBucG06Ni4wLjE=-099bb9d4ab.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-        "sha512": "ec6a6cfd75b299b2e4d902d82b8373a4c3ab623321748c57b88bf2d9006c2c4ea58eea1d2af7645acfdca72249dc25485691f43a2d47be0d68bdb3332dd14106",
-        "dest-filename": "file-entry-cache-ZmlsZS1lbnRyeS1jYWNoZUBucG06Ni4wLjE=-099bb9d4ab.tgz",
+        "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+        "sha512": "5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
+        "dest-filename": "file-entry-cache-ZmlsZS1lbnRyeS1jYWNoZUBucG06OC4wLjA=-afe55c4de4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -19903,13 +19952,6 @@
         "url": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
         "sha512": "a8ea3d17e74c5260b62dc6f805b56f9ca2714cf8c29be451a5ee200ee1abce42fb984565fdd8d84aed8e750d8f6b7d36378a2a91283d8abea368b589d94495a5",
         "dest-filename": "fill-range-ZmlsbC1yYW5nZUBucG06Ny4wLjE=-e260f7592f.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-        "sha512": "62c1a97b75872caf19622e2d583836272dde6d1cf6ad7a300f19e57786e4401d3471cff5670f405a70b48bdced0c98ad8afb50bda23d29a2f22ab73e8415b4ca",
-        "dest-filename": "fill-range-ZmlsbC1yYW5nZUBucG06Ny4xLjE=-a7095cb39e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -20068,6 +20110,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+        "sha512": "7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb",
+        "dest-filename": "flat-cache-ZmxhdC1jYWNoZUBucG06NC4wLjE=-58ce851d90.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
         "sha512": "6fab2e103fb9ff7ad3a5405d1b582ea4897c30f14200c034417c269632e1bc250a714bdd138816932f73a6e1827171ceb33e09f703c6356aba38aa66233cf785",
         "dest-filename": "flat-ZmxhdEBucG06NS4wLjI=-72479e651c.tgz",
@@ -20075,9 +20124,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+        "sha512": "308d6ab3b2e8e12cb0d043b3525d318ecda5b287aa164bb8e0aa6781f21db87058bf39bc876fbb2bc60c421d49b55555ad4be12e9370a958b80c445e8142613d",
+        "dest-filename": "flatbuffers-ZmxhdGJ1ZmZlcnNAbnBtOjI1LjkuMjM=-e2086e7f9b.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
         "sha512": "f3fb0e6b0a3cb49e103815fc6254013312fcf912d97f13103a27fda342942933538cc6049563c4d2bfe6e55345c5345dd0d4b0f2a4b2f1d6a3af05f84582351f",
         "dest-filename": "flatted-ZmxhdHRlZEBucG06My4yLjQ=-272cce99b0.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+        "sha512": "3e30ec7bb47385c3e4209c32e6deca3d641267d7006f341771a7ec7ad4280fbb0e2514251a290d6f1ef2669d8ea2d0e7272ac371bc91ab74ed6f5f2260eaa4c4",
+        "dest-filename": "flatted-ZmxhdHRlZEBucG06My40LjI=-a9e78fe5c2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -20131,13 +20194,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-        "sha512": "75e1b63f425f8eb4f1979d171820f27c8f7b646542c48a5f29899fcab439e27e453bfd207c8112f02fcfb25ea45950e8962cdc69ac592674d2d1048cc6f9ec05",
-        "dest-filename": "follow-redirects-Zm9sbG93LXJlZGlyZWN0c0BucG06MS4xNS4xMQ==-07372fd74b.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
         "sha512": "d55cceb6e10cf290bd48553513ef0a7d38d9c8cced46c8047f0425e38cfc036e6ecb5de34b34e3e9dc8ad837f9da2574be01c27c1c0b84359ebcb9fde70e6fe9",
         "dest-filename": "follow-redirects-Zm9sbG93LXJlZGlyZWN0c0BucG06MS4xNS4z-60d98693f4.tgz",
@@ -20148,6 +20204,13 @@
         "url": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
         "sha512": "c1637ad9821311a3a948ae7ce0465725a7c7d401a93bc45580495f92e5db4ceacf5f87c87cec84a56fc2b2235df09758ac0a0ebda7d14ce127bec3befaa0aa14",
         "dest-filename": "follow-redirects-Zm9sbG93LXJlZGlyZWN0c0BucG06MS4xNS42-70c7612c4c.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+        "sha512": "cb9acdfee3ac69d153fc97d8c21c514b947b41c7be837cc6f7bf89aed159942f64957fd6e610fb8a22f349c2389d9a944bb0cd51d84f830e3123c5b62ee5e553",
+        "dest-filename": "follow-redirects-Zm9sbG93LXJlZGlyZWN0c0BucG06MS4xNi4w-3fbe3d80b3.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -20411,16 +20474,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
-        "sha512": "5564918a2e2dd00166ea2c451662cbc75b7bc12d6087e724a1af3868e79aa46ba6d21f8465dd44844ba6481f997432e710fbae72c541f6807b7312476a9e807e",
-        "dest-filename": "fs-extra-ZnMtZXh0cmFAbnBtOjExLjMuMw==-daeaefafbe.tgz",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+        "sha512": "0935ddeab93f337fd42cd423f0506a0561d80556326d0dd53c1c34c462857b7b6e1fbcad4fa0029efce9210dd466d07ccaf50a0b67179f56bec7ee445502e8bc",
+        "dest-filename": "fs-extra-ZnMtZXh0cmFAbnBtOjExLjMuNA==-1b8deea9c5.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
-        "sha512": "0935ddeab93f337fd42cd423f0506a0561d80556326d0dd53c1c34c462857b7b6e1fbcad4fa0029efce9210dd466d07ccaf50a0b67179f56bec7ee445502e8bc",
-        "dest-filename": "fs-extra-ZnMtZXh0cmFAbnBtOjExLjMuNA==-1b8deea9c5.tgz",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+        "sha512": "78aa51280a2f76966d4755a8a4b1f19415af0203e7cb7738817d46e498709a6c385c98f489f483e6a0794cea3c866034c2544a0c0380844135c953e0b3a16072",
+        "dest-filename": "fs-extra-ZnMtZXh0cmFAbnBtOjExLjMuNQ==-dc8408818e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -21006,13 +21069,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-        "sha512": "afc869123890118945d9053475fddd4be9f1c5222b797412d6a461309334439343751dfce82ee36fb1f0c2877c1608ae7b1fa4d0616381fb75f32bf19b95e809",
-        "dest-filename": "glob-Z2xvYkBucG06OC4xLjA=-9aab1c75eb.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
         "sha512": "3d3e9745e27e0f4ec9bc6a3140c913eaa8e2fe354d7d7fe1dfae171d9396791cf2eb8b1216bfb1279397ecb2376f830f43374be07f18f0cd31ccfa6c54cc00f1",
         "dest-filename": "global-agent-Z2xvYmFsLWFnZW50QG5wbTozLjAuMA==-a26d96d1d7.tgz",
@@ -21069,9 +21125,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
-        "sha512": "76443de7bb924561f0ec21572d4b541d02378376960296217cd4763ba8e7ffdd3bae2c9360a5419b161544e901718eb5e05492792261ed79bb4ab5160b1bc931",
-        "dest-filename": "globals-Z2xvYmFsc0BucG06MTMuMTkuMA==-f365fc2a4e.tgz",
+        "url": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+        "sha512": "a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5",
+        "dest-filename": "globals-Z2xvYmFsc0BucG06MTQuMC4w-03939c8af9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -21083,9 +21139,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.2.tgz",
-        "sha512": "6509d214ed656bc3fb6ae20e4040a79b4b12ba831e692ab4104757301145d9024ee2e35cc1bca14a01b732bb9635b153a822e6c55c063a5ecb67d9004af1dd79",
-        "dest-filename": "globalthis-Z2xvYmFsdGhpc0BucG06MS4wLjI=-bfd8553248.tgz",
+        "url": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+        "sha512": "b1ea5f7e44fcb2dc272186ec301a6808726e24ce65f7c154176027134ee17ef1349bfaa9dd1e7cea1c388c5e2e69d6e1be0d68a08773baeec2b1f0f68f309a34",
+        "dest-filename": "globals-Z2xvYmFsc0BucG06MTcuNi4w-2bf0febf31.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -21212,6 +21268,13 @@
         "url": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
         "sha512": "fb11906346320160a7ab2ec277efa173626a318ce59b4746df425dd1b79a03ae2c44eafc0b89edf1873d579468ddabe54940d3374ba5a8ffd504a8b5fe52f283",
         "dest-filename": "growly-Z3Jvd2x5QG5wbToxLjMuMA==-77f9abc3a8.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+        "sha512": "63c4f8bd88447f024e4dba2e444bc6fb75c3b23afc137908afbb9ff8967405896816cb6d88753459fbc0355b11ed3c4d5096bf5a90a7c3f227a3fa7e0de06105",
+        "dest-filename": "guid-typescript-Z3VpZC10eXBlc2NyaXB0QG5wbToxLjAuOQ==-829dd87866.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -22203,13 +22266,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
-        "sha512": "4f5d2abe4c34cf3e309e6e7ad253848343e8bd5a945ee3858611c0922c70f3fb32732ed326deeffd1ae410a1109c0c36be23d226eea202412bc67cd1d20f0fa5",
-        "dest-filename": "iconv-corefoundation-aWNvbnYtY29yZWZvdW5kYXRpb25AbnBtOjEuMS43-10.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
         "sha512": "bf73179d901cbe7cb091350466898801cb657bb4575de79d391df5c3097b565ca85cee108bd6abbd27a73505a77b54dc4708422f51f02c8db56c4a9da63f3fac",
         "dest-filename": "iconv-lite-aWNvbnYtbGl0ZUBucG06MC40LjI0-6d3a2dac6e.tgz",
@@ -22315,6 +22371,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+        "sha512": "1ece7dc4135f508ba730581601b197e5cabaf3ddc86d68382a7ae36d8c17dedc74ceda2b5604c303a076b317fc7a31c9e30cfc06a194318967ccd05eaf936f1a",
+        "dest-filename": "ignore-aWdub3JlQG5wbTo3LjAuNQ==-f134b96a4d.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/image-data-uri/-/image-data-uri-2.0.1.tgz",
         "sha512": "05987bdb51764394f005dc298aaac1ac711d8fc75a8fc2ae3192bf0ce0b2a90973d42a85861b9959b2b964252702f149afc2da2874da5a5f636b7fdadc30b613",
         "dest-filename": "image-data-uri-aW1hZ2UtZGF0YS11cmlAbnBtOjIuMC4x-c36b11a049.tgz",
@@ -22378,9 +22441,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/immutable/-/immutable-5.1.3.tgz",
-        "sha512": "f9c8507437efb1c485d5226abf6827e1244ed99c92df12f7afb216ff0584133af32e2b273a52a242ee72b42fc154d712d790b7f564f61e0fdb8ca8c331cbbece",
-        "dest-filename": "immutable-aW1tdXRhYmxlQG5wbTo1LjEuMw==-6d29b29036.tgz",
+        "url": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+        "sha512": "9bc9d57b3debc2b8265b1b4b32dd596170762efece2989ff762b32c409520d8025292945a0f3df20098033f339c6a2f89b80bfc003f0ed2dbf08d6948a2d47c6",
+        "dest-filename": "immutable-aW1tdXRhYmxlQG5wbTo1LjEuOQ==-dc61ea6f79.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -23197,13 +23260,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-        "sha512": "a8fd6fa3341123e04c38f723173ae35ee42f75a936a47354319a1e1b67916e24aacaf6c47ffc10b44393397d60ba4e84deddfa4646aa892b7c03fe981253712d",
-        "dest-filename": "is-interactive-aXMtaW50ZXJhY3RpdmVAbnBtOjIuMC4w-e8d52ad490.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
         "sha512": "cfb08c14636b10dab988507d06aa3ae1793a63db20f9ea6ad66c8871d1da1a76cc4d83b1bf3b04b5d62a414ca507b2f17e4be0aeb8cfdf64fa6307228a8f5421",
         "dest-filename": "is-lambda-aXMtbGFtYmRhQG5wbToxLjAuMQ==-93a32f0194.tgz",
@@ -23582,13 +23638,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.2.0.tgz",
-        "sha512": "c07f94efba26711cdebdf206f1d0e14d2d15f73672c1e6a47c3d351542e5f7bfb41078894d366d26ac4f4a4208a3f4833effe2d3b93f0bd8c03d8fa3c0b2de51",
-        "dest-filename": "is-unicode-supported-aXMtdW5pY29kZS1zdXBwb3J0ZWRAbnBtOjEuMi4w-2d90b4b3ce.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
         "sha512": "188f968dece13cf71b33eb6a13d2e79ac639aaa8f01f34ef8c9dfac31617e6e8cd5de7d2509fd3d7baf96ea0d5f322e1720079f4a4cf34e73d3bd7261d33d6b0",
         "dest-filename": "is-url-superb-aXMtdXJsLXN1cGVyYkBucG06NC4wLjA=-fd55e91c96.tgz",
@@ -23760,6 +23809,13 @@
         "url": "https://registry.npmjs.org/isexe/-/isexe-3.1.1.tgz",
         "sha512": "2e907fe7807eff627986a43b8a66477dd537d4e96042ac7b6627159649bd93383dff0f0628b11c15f265fedec30840ee78ec81003eb3082c133ba173b3436811",
         "dest-filename": "isexe-aXNleGVAbnBtOjMuMS4x-7fe1931ee4.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+        "sha512": "14552d64ca6867c46a1d2dd77971261d62c0e2d847f99c42bf694e88f227d5773b0b1aea856ccd483cc3fbf7214bfcdb61ece68b058b7500b4f497502a6b613b",
+        "dest-filename": "isexe-aXNleGVAbnBtOjQuMC4w-2ead327ef5.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -24198,6 +24254,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+        "sha512": "7a48a50923758f046f21b81e83fe7b60587ca900cd6f00dbf714ffaaed830076c5159522708978ca055a02fcef78c84c56bdcb9e948a4cd9f0b7c3e839f98a85",
+        "dest-filename": "jiti-aml0aUBucG06Mi42LjE=-8cd72c5fd0.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
         "sha512": "f45cd08c9ecc013b35b52a67728d4ae9aca2604ddf8a0b25ad703bd86d8743f9fbe91cef625a1fca2e5033e897e1846cfe9bb7cb3c655504924f6dfe74c0e49f",
         "dest-filename": "jmespath-am1lc3BhdGhAbnBtOjAuMTYuMA==-cc8b4a5cd2.tgz",
@@ -24292,6 +24355,13 @@
         "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
         "sha512": "a90293e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0",
         "dest-filename": "js-yaml-anMteWFtbEBucG06NC4xLjE=-a52d0519f0.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+        "sha512": "78f5acbda9efd035ae0d1b16f1d9edf91e23437d52091090ee184d70f5d93eca016627a6b9935819feda75976a5f60fcea3eabbcaa774690b155349bf164253b",
+        "dest-filename": "js-yaml-anMteWFtbEBucG06NC4yLjA=-51de2067a2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -24681,9 +24751,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz",
-        "sha512": "18ba0823a851d1ce2d8b6e3780cb39ff545bdc1f808f030e7e3626f7ba6ed053906bb247e7a86007161fe562b6e76e5c7926c1635723799f7293df463cc07a2b",
-        "dest-filename": "knex-a25leEBucG06My4xLjA=-12eb978ebe.tgz",
+        "url": "https://registry.npmjs.org/knex/-/knex-3.2.10.tgz",
+        "sha512": "a32a531dfadcf62ef68b2c5a51004a1cec6172bd3133ae4c3dfe85a4dd369e29ac7ed5f0cd7a6b2242e37d776e6ef85bbb83cc58ba74db7abca3c098bc74ae67",
+        "dest-filename": "knex-a25leEBucG06My4yLjEw-6d043d0d55.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -24709,9 +24779,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/koa/-/koa-2.16.3.tgz",
-        "sha512": "ccf3ee22dfa4bb5882a45051c2c78c70f610d5c24bf25eb4ad298a78eb867ce5f213a6274c199fd9a10534bd87406ac3d1c3dc2cefedfaff514e00be7f0121fe",
-        "dest-filename": "koa-a29hQG5wbToyLjE2LjM=-62b6bc4939.tgz",
+        "url": "https://registry.npmjs.org/koa/-/koa-2.16.4.tgz",
+        "sha512": "dc09f41822c3491df8b6c08ee07f1379ff0fa769e0b5a6430199ec58961e96a5d42b9c32887bc622d80aff17129261cb4939f525c868d66450b367a1473bca2b",
+        "dest-filename": "koa-a29hQG5wbToyLjE2LjQ=-f49e76c2cb.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -24730,9 +24800,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/lan-network/-/lan-network-0.1.7.tgz",
-        "sha512": "9a722500432ee0ec84bd435dcdca3dc69b81f5855c3e441e73e42c8327010ad3d9bc4a963c20cf7db004e0e24c741056a595ada429f5c70f632589708d6239cd",
-        "dest-filename": "lan-network-bGFuLW5ldHdvcmtAbnBtOjAuMS43-005b6a30c1.tgz",
+        "url": "https://registry.npmjs.org/lan-network/-/lan-network-0.2.1.tgz",
+        "sha512": "38d3e76b30bde952839ed69bf63f492b0216859e1951c781e00f44a6ee12b20d216059ad1d949e43e9f5e672304c599c0542ad13139eafc593278185f4c3bae0",
+        "dest-filename": "lan-network-bGFuLW5ldHdvcmtAbnBtOjAuMi4x-6c39acaaa9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -24856,9 +24926,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/ldapts/-/ldapts-8.0.36.tgz",
-        "sha512": "3c659f02302e911415d0a72fdf28b0d0c30821c843d301db238738a025d50c1112d6b114d35b67687f1859fa117c66011256bec63ae5cfbc5dfe97acd9a8a21d",
-        "dest-filename": "ldapts-bGRhcHRzQG5wbTo4LjAuMzY=-812c290c47.tgz",
+        "url": "https://registry.npmjs.org/ldapts/-/ldapts-8.1.8.tgz",
+        "sha512": "5a976fa3eff40d1108ca761fda17b679f1ed8e9b6be730fb7697ac4a465626a7d074c120493cad108b12655ba80d28a2135f92a577f77a667b7b0c46053a3b3f",
+        "dest-filename": "ldapts-bGRhcHRzQG5wbTo4LjEuOA==-3d9e80005e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -25045,9 +25115,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
-        "sha512": "943223e119d898aeff9173326bea89b269111641a895c8978ebb19e8f0b6e467537d638059eb51d196ec3574408f51071c899149a95cfb0859160e7a1790d5a3",
-        "dest-filename": "lint-staged-bGludC1zdGFnZWRAbnBtOjE2LjIuNw==-c1fd768530.tgz",
+        "url": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+        "sha512": "9415adf21ba387f0a3cacc391985666691475c30a067386b3a6f2f6dc51da1b00364d38afdb46c86bda43370df82baed4750d085fba95bd82721739f8858be6f",
+        "dest-filename": "lint-staged-bGludC1zdGFnZWRAbnBtOjE2LjQuMA==-eb7aa0d43e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -25353,13 +25423,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-        "sha512": "8edb6645eedb46c7b9d8eb1620c0cb697c56a91026b4851c70043781aaef882a898da7d739f34c3b4c8c7cda5d0facdb19a4d4d0fe4dcfb7bb8004fa70a98947",
-        "dest-filename": "lodash.truncate-bG9kYXNoLnRydW5jYXRlQG5wbTo0LjQuMg==-7a49561612.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
         "sha512": "c5f05a5d077daf277d765483be7bc8d25bf17cb2656006735e89946332cab5478e42f38fe698aa016b86b6b8567aa6972bd861a0cfe2c89739015f977ec5f71d",
         "dest-filename": "lodash.uniq-bG9kYXNoLnVuaXFAbnBtOjQuNS4w-86246ca64a.tgz",
@@ -25388,9 +25451,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-        "sha512": "2e055332942d228a428bbf5225e0e23f44df5a2e4234473f2ff691753877c88be66574e785e5a92a3499867bcc97c8976c2d6d160f607471c330ba15ec29c6fb",
-        "dest-filename": "lodash-bG9kYXNoQG5wbTo0LjE3LjIz-82504c8825.tgz",
+        "url": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+        "sha512": "74c22789c4cf544f1dd5ee68b5fc269a3971919a14a6254bc32793754b22fc26a3fe07f3cdb941702139b111d5fc0b23b829b15abb5ed93346498b82782abed1",
+        "dest-filename": "lodash-bG9kYXNoQG5wbTo0LjE4LjE=-306fea53df.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -25416,13 +25479,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-        "sha512": "974c760efad6dbde02f6e0c2a107b555253881fe76f4591267a95e065e138aa647fdefb447b8527c740136eb7698dca00e01f0bd81df14b9fa3b16f75568f6ac",
-        "dest-filename": "log-symbols-bG9nLXN5bWJvbHNAbnBtOjUuMS4w-7291b6e7f1.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
         "sha512": "f627bc22d3d1ead8d8e6e60987c2bf66bbff44c67954e94e5afb597441d849314a65f2013d06bdb4e0047805a177e02722778b276db0e5f8ce62da2eb695aae7",
         "dest-filename": "log-update-bG9nLXVwZGF0ZUBucG06Ni4xLjA=-5abb4131e3.tgz",
@@ -25433,6 +25489,13 @@
         "url": "https://registry.npmjs.org/logkitty/-/logkitty-0.7.1.tgz",
         "sha512": "ff7111db40934db6a1ac2ae961f3e7ed76afbfd762051399a685c65590d6330e1bfd7e2eb94c000b4922f39b60b1d31138d511c8825b70ebd2f7842c50160f6d",
         "dest-filename": "logkitty-bG9na2l0dHlAbnBtOjAuNy4x-1b9ab87319.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+        "sha512": "98d0206751a6c8d843ec0baa9d31b7fd5436ea8efad3e65804f2a33efba03bcfa72db61f5fa4d5a493ec781be8a5b758faaa59fe52949e611cd4b799612dd000",
+        "dest-filename": "long-bG9uZ0BucG06NS4zLjI=-b6b55ddae5.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -25647,13 +25710,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
-        "sha512": "36038f6d189a40cd740d85ef377fe1846548d8ce4cb484c5af2cc11b11cce69e309c5c6c5426f192b06b0ec93e119e4e0788c4393ec08c3c6d745f8a544153ef",
-        "dest-filename": "make-fetch-happen-bWFrZS1mZXRjaC1oYXBwZW5AbnBtOjEwLjIuMQ==-fef5acb865.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-11.1.1.tgz",
         "sha512": "acb592ec60924dc12e8e3541b3662a1bb638eb8deef2e72f08979246a88b6217acac3bb37ae148937ef1444cc0b1f41aab397c6fdacd084e26e89f2dbd7e10f3",
         "dest-filename": "make-fetch-happen-bWFrZS1mZXRjaC1oYXBwZW5AbnBtOjExLjEuMQ==-b4b442cfaa.tgz",
@@ -25839,13 +25895,6 @@
         "url": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.2.tgz",
         "sha512": "16dc2712eb8afb6c9553b8281a7fcc27458164c33d64f814f6ca6a945b3bfc0fe90c850d48e41985480ea9809f89c22e47641a167aedf0b1ea056b1b4c0a08e7",
         "dest-filename": "markdown-it-bWFya2Rvd24taXRAbnBtOjEzLjAuMg==-4f48271bbd.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
-        "sha512": "13375af394e825406133a586686eaf79ab32ca6f936ecddc300c3f66138fa97898b2bd238287015778f79f1fb8964e3ba652e522a8f0b939bfcb0548fb38c9fc",
-        "dest-filename": "markdown-table-bWFya2Rvd24tdGFibGVAbnBtOjIuMC4w-8018cd1a17.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -26753,13 +26802,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-        "sha512": "3d7c1f06162ed210423f0f039f413e58361beda7f77522d558a8b71c6bfce08745e13c85a02d32b3115dd06a31c3b9d2bf84ff3f3109431b18b0488508aa3604",
-        "dest-filename": "micromatch-bWljcm9tYXRjaEBucG06NC4wLjg=-6bf2a01672.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
         "sha512": "d75e5f2e1bd956a5b01cf6c29729edc4455f5437e5f432cb4ee26fab78363bf3b18bc022368b801ef0d2cc74b4be250973e579be6ddeabdd57c2a9fd769e2344",
         "dest-filename": "miller-rabin-bWlsbGVyLXJhYmluQG5wbTo0LjAuMQ==-2a38ba9d1e.tgz",
@@ -26942,6 +26984,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+        "sha512": "3142e454b7ca1980c561e8cfd3b40ebab0cb2d0a5c8e4ec5c3eee35d2d91d9ccd1433479eb21d1bde5393432443af887fa111364a4a4224e5cf93db71a315432",
+        "dest-filename": "minimatch-bWluaW1hdGNoQG5wbToxMC4yLjU=-19e87a931a.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
         "sha512": "c891d5404872a8f2d44e0b7d07cdcf5eee96debc7832fbc7bd252f4e8a20a70a060ce510fb20eb4741d1a2dfb23827423bbbb8857de959fb7a91604172a87450",
         "dest-filename": "minimatch-bWluaW1hdGNoQG5wbTozLjAuNA==-3b3f17f765.tgz",
@@ -26970,13 +27019,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-        "sha512": "94ac15ff56eba46ea6054147b5becd526b400426f65996669b6c0d88e0398406fc55d092e01dddb4c5b2bdca1589c730016fc23844635cbb74ccfd735d4376ea",
-        "dest-filename": "minimatch-bWluaW1hdGNoQG5wbTo1LjEuNg==-126b36485b.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.2.tgz",
         "sha512": "c72e2aef0a2edef5280bd935c464d773e6b035d19a1951ed15469ecbcb625f81f5411734e0367fae60c5c0d9b6101b2e60484067a4a032661fdc89c663a39ab8",
         "dest-filename": "minimatch-bWluaW1hdGNoQG5wbTo3LjQuMg==-f7682880ba.tgz",
@@ -27001,6 +27043,13 @@
         "url": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
         "sha512": "2aa5a1f957217f170c3510098e3dad9ec48974d6c7b1582790185336b5bb023568e8ebcbb71c3ccdf4fda0bc35252a21945cc9f230a84e06a85ef27e907b7a7f",
         "dest-filename": "minimatch-bWluaW1hdGNoQG5wbTo5LjAuNA==-4cdc18d112.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+        "sha512": "381c0137d00be1daa61139694b6cdab31faf4de59c956ce46e57d993b2930398f78de38e373fed4429d9a26532bcd83cdf02f966ff52b3a1cc2570202fc47662",
+        "dest-filename": "minimatch-bWluaW1hdGNoQG5wbTo5LjAuOQ==-b91fad937d.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27050,13 +27099,6 @@
         "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
         "sha512": "0861f579b94bab6e98d79f80ce4edecb8c61d09fd77c97eb0a8c792c32622aa2364368b038b38aae598868e0e24904bc775f236a517acb62b678f526d0299287",
         "dest-filename": "minipass-fetch-bWluaXBhc3MtZmV0Y2hAbnBtOjEuNC4x-4c6f678d2c.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
-        "sha512": "2d3e3d662dbf58c44e1d8a2a1a0765408661f262cf6663ab37635d263317c587b89e437a154cae3ee38039e74d243af1d0844683dfb882e65ec2da7c844e93c4",
-        "dest-filename": "minipass-fetch-bWluaXBhc3MtZmV0Y2hAbnBtOjIuMS4y-8cfc589563.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27278,13 +27320,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-        "sha512": "9079a8c9b70f57c4aacb9f43c0d0d8dc979fafae252bf6f2fdd6b456215cb80e031f4bd083943a65ee558a6c647d03520be325b3f2b1e77b3b4e33f54611440d",
-        "dest-filename": "moment-bW9tZW50QG5wbToyLjI5LjE=-8518e781f2.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
         "sha512": "e4b0bd48ec6349cd8717abced82cae4c3362bc4768cf622fc892468fa5fc0c9d1e1727eccc4d1088477e897981bd43f7587c528c51ffbc8b00d04374d1c82bf3",
         "dest-filename": "moment-bW9tZW50QG5wbToyLjI5LjQ=-157c5af5a0.tgz",
@@ -27404,16 +27439,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
-        "sha512": "5697fdaa7556d5168392834a154bdfc6a01bb48f2771bf0e265a99f70c295f358f12cbec0759ef7548baa18ac722443563fb4c0e7af58789dccd2d1507d5f292",
-        "dest-filename": "nan-bmFuQG5wbToyLjI0LjA=-479f696011.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-        "sha512": "b5a72f1b3518e68d83f02061dabaf0c723688d4b19354db38cd4f3290ae48062504db1807c0ad559748a301a2405e7a0e82ece2d1194132a059586df796408ab",
-        "dest-filename": "nano-spawn-bmFuby1zcGF3bkBucG06Mi4wLjA=-117d35d7bd.tgz",
+        "url": "https://registry.npmjs.org/nan/-/nan-2.26.0.tgz",
+        "sha512": "fe1df221dc7376fe19f92dd0d90f38800b4ead85bb6ba83458605c4e55a4ced447a86bfd7b8b8e6641e65fdd308a97f30db4619b2c72c4b888cead24d84a014d",
+        "dest-filename": "nan-bmFuQG5wbToyLjI2LjA=-e6f8a720f2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27530,9 +27558,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/nitrogen/-/nitrogen-0.33.2.tgz",
-        "sha512": "d5fca948ca83536be7443988f0f607d05dff2022e046ab0a0ad3b2352317eeb42c1bd0fb1bacc836f647d15934ba78f34ee75ee5237c5cd14ee629b82eb182bd",
-        "dest-filename": "nitrogen-bml0cm9nZW5AbnBtOjAuMzMuMg==-ace466a340.tgz",
+        "url": "https://registry.npmjs.org/nitrogen/-/nitrogen-0.33.9.tgz",
+        "sha512": "7f0506a23c975cea1670ee108f7761f6edb957461ec00d2648ce892f215fff80590a9b9fd1c6266746a26f2b057a4b5533e9b6cf165876a4ce7198a2d50e454c",
+        "dest-filename": "nitrogen-bml0cm9nZW5AbnBtOjAuMzMuOQ==-dba4241f23.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27565,16 +27593,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/node-abi/-/node-abi-3.47.0.tgz",
-        "sha512": "dace81d8259933ffe43e0c27b88d0aad8c0d8df741c84db9cef01a129abd207e3370db1aac7f0886efd4b97e9730f12880303192e5057999fad295cd1c0aa7dc",
-        "dest-filename": "node-abi-bm9kZS1hYmlAbnBtOjMuNDcuMA==-9b70640345.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-        "sha512": "89b3cade203ebda6357848c44a442433405b0aa14e6993225d14ed741d2eedbe1d8ed63a267b23bcf7541d5320eb142ddc1f1fa534d61c8f40f800e333d7ebce",
-        "dest-filename": "node-addon-api-bm9kZS1hZGRvbi1hcGlAbnBtOjEuNy4y-6bf8217a8c.tgz",
+        "url": "https://registry.npmjs.org/node-abi/-/node-abi-4.28.0.tgz",
+        "sha512": "41fa795d92f57090ce69b393f07e609ea31398ce0d8ef6331e9e08fcab7f4a5efa39590e0411d11653eca46574858bcca2a42cca91634ff629eca9b46de5d6f6",
+        "dest-filename": "node-abi-bm9kZS1hYmlAbnBtOjQuMjguMA==-2fe3e269c5.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27593,9 +27614,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.0.tgz",
-        "sha512": "7ed8534ec8bc0b16815cc681003ed24f6bb2970bec9d8c61d8f7da49cc29321a2ce8a95215a8d740f70ce2880d135ab6b372dbcfd1821aa7881c2f82e8e6672a",
-        "dest-filename": "node-api-version-bm9kZS1hcGktdmVyc2lvbkBucG06MC4yLjA=-26146d0d4a.tgz",
+        "url": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+        "sha512": "db13ff20618c9a6490a48d7e3bf93bda317fca4bd9f3d25eb8a5f74cb24060f0d52d46a5aec86b2c791e55c08266a1bf7846badf972bf08058ce09c3bccd8ef1",
+        "dest-filename": "node-api-version-bm9kZS1hcGktdmVyc2lvbkBucG06MC4yLjE=-78a3056873.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27607,9 +27628,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
-        "sha512": "74e6a5ebbfff9e884d81859bfa75a683976415d2300e6f04a5e19831e90f32b9e0577eb7ee5aa75f495b51c0ad8226c74f3e92133ec30088cabca0c56029ced4",
-        "dest-filename": "node-cron-bm9kZS1jcm9uQG5wbTozLjAuMw==-f088043da4.tgz",
+        "url": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+        "sha512": "9608a61073c4fd00e0165cb04ddf324d1eb5a6dba05f741eaf6f5e7dec96c36aefdb9f47b4604d9f5bd9566a7c941f6ea3dc02d2dfc04f8886a97c626be08916",
+        "dest-filename": "node-cron-bm9kZS1jcm9uQG5wbTo0LjIuMQ==-7550b105e4.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-diff3/-/node-diff3-3.2.0.tgz",
+        "sha512": "bcb876c49152ca78812d80c40db5caa83df67d0e6f0319984f885ca3cb74107438090e010c786c862ee476f0dce98d4cc064a2d4c865e2e9d4ba43db09ac9977",
+        "dest-filename": "node-diff3-bm9kZS1kaWZmM0BucG06My4yLjA=-594cdf658d.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27663,9 +27691,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
-        "sha512": "74f12d39e32f17d54c71857fd566fc08fa15017b69e8c28c95c6c0b7875daa61aa509e9f41915790d64d90d95f7afb4d906b5a4a85dffef34d352be0add5f0b4",
-        "dest-filename": "node-forge-bm9kZS1mb3JnZUBucG06MS4zLjE=-05bab68686.tgz",
+        "url": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+        "sha512": "eb12a243e72987d2889ab461d15b231f677cfc65c0e0520c96053807be7b888d40a6f73203d565a2e3f4c992616b4d55fa1b8898efa428c53b8a1fb6f84d787f",
+        "dest-filename": "node-forge-bm9kZS1mb3JnZUBucG06MS4zLjI=-dcc54aaffe.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27687,6 +27715,13 @@
         "url": "https://registry.npmjs.org/node-gyp/-/node-gyp-11.5.0.tgz",
         "sha512": "adaecabe58719f957d4a5caeb34ca031ada1f94a84c4fa942247e4ecf73c4132d3f79e892d2cb9d6e585c07b48632d2f23c701e010e173f4b4dfef3cd0ccbf2d",
         "dest-filename": "node-gyp-bm9kZS1neXBAbnBtOjExLjUuMA==-15a600b626.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+        "sha512": "38c70f36fa9308552735a06599d82afa57cda98ee04e24a63510e3637b805d1cae75e299119c6edc22ed8cc42bc78cd9c425f66ff9a936a4edc2e08981784793",
+        "dest-filename": "node-gyp-bm9kZS1neXBAbnBtOjEyLjQuMA==-b1f5228239.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27824,9 +27859,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
-        "sha512": "8acf7ab7c17fd7ffd41c08cd3c7a5bb0d638e842cfa5fb46528495357c147cc93fa9d8d2ca562b592bb55dabd54c13a7e76ea4162391ef7dc04e0341090c87d2",
-        "dest-filename": "nodemon-bm9kZW1vbkBucG06My4xLjEx-0f43d2c70a.tgz",
+        "url": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+        "sha512": "8da923662f7752d0778c7316b172faf055d2028b1b2df634227e60b4aab79e22d292b5b39eb541cd714d38430951f73df8a7bb4875a8019b2232434fdefaba27",
+        "dest-filename": "nodemon-bm9kZW1vbkBucG06My4xLjE0-187aa93fc4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -27859,13 +27894,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
-        "sha512": "6702e96d381d86e6549d9ce377b9dbd5957ee03a220bafec7e254aa24ef6ca6ff84e57fe0c57651d8993d893e670d35657a3e2dd20dfd644fe038afd453b93f6",
-        "dest-filename": "nopt-bm9wdEBucG06Ni4wLjA=-3c1128e07c.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
         "sha512": "b5a336e158a28a64ff5e7b716cfc89433086fa9e0428ea600f79b11705b7f261a3554adf11140e798e040c78dd9e9b6db5f1ee1d05c5c7e9533f4f10fa62daff",
         "dest-filename": "nopt-bm9wdEBucG06Ny4yLjE=-95a1f6dec8.tgz",
@@ -27876,6 +27904,13 @@
         "url": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
         "sha512": "89e1aee36bbf42c6b84c592d99a284c0ce8c407d293969da07786dce1d0946dc7ce3e31e6dcd1c6d960de5b0bee964d9e3eefbc6b2fd3e7e66ec257a548915ec",
         "dest-filename": "nopt-bm9wdEBucG06OC4xLjA=-26ab456c51.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+        "sha512": "661ab76bec852ab63048196e2f81fd5cfde6df2e6ebd0901ff4f42c03aee0a246647f5096279fd5b8478f2bcb4b860bbd1a7933ca2f29c1b6c70ff5e7c515c3f",
+        "dest-filename": "nopt-bm9wdEBucG06OS4wLjA=-56a1ccd2ad.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -28020,9 +28055,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-9.0.0.tgz",
-        "sha512": "6e6cab690c8ef70032170cabfa8b8cadbbf798563f51963c9e5068ae0a9f4f0ef7e50b557c05012acec6acefebbc9072a0a9e7c3340894816af565dd7e448bd2",
-        "dest-filename": "npm-package-json-lint-bnBtLXBhY2thZ2UtanNvbi1saW50QG5wbTo5LjAuMA==-449a0d4235.tgz",
+        "url": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-9.1.0.tgz",
+        "sha512": "10cf9cd454a09dcc323690517fe5a5f76cc27ebb41887645644fa772a404aac5bfb4b4dc1d7fc650708374fcc8d1714a0591efcfe8770be3afdd57f025f5bd0f",
+        "dest-filename": "npm-package-json-lint-bnBtLXBhY2thZ2UtanNvbi1saW50QG5wbTo5LjEuMA==-6dc2901bb6.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -28468,6 +28503,34 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+        "sha512": "04ea2899d1d898d44be6be224386ccbec976b74fe1cd543738cdcf1c3d20c5e5eed4f9a082a06fde9b9989c11454e03702d1c7626a99b63323f4539f1ab0134f",
+        "dest-filename": "onnxruntime-common-b25ueHJ1bnRpbWUtY29tbW9uQG5wbToxLjI0LjAtZGV2LjIwMjUxMTE2LWIzOWUxNDQzMjI=-9a028b8ead.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+        "sha512": "19eb8f64ee94fcb0495efc1d6aa1dbb949a85e211d7828d68bf106ed8d473670f0258ba4e9651b357a45ea5b92518f32012ba5ddc99494b1ab0822f5660557a8",
+        "dest-filename": "onnxruntime-common-b25ueHJ1bnRpbWUtY29tbW9uQG5wbToxLjI0LjM=-699fe72ebf.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+        "sha512": "247efe7336dcf002c0f35f6f95381c57e436d78ffe56319e0470e35fcd7e6420f43c254220518536d4f4578b171bfd495f2a4a3e049c41c0778a3fe19376274e",
+        "dest-filename": "onnxruntime-node-b25ueHJ1bnRpbWUtbm9kZUBucG06MS4yNC4z-56a7941955.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+        "sha512": "303e92b38192a50068eb3aa8273c93f4b45b298b3bc7f255376dc54f6e04704be5a85e15bb33ce787e97dfca2b64f2874036e9ae7ecaf92069bb4fe68f60908b",
+        "dest-filename": "onnxruntime-web-b25ueHJ1bnRpbWUtd2ViQG5wbToxLjI2LjAtZGV2LjIwMjYwNDE2LWI3ODA0YjA1NmM=-16ec05c7b2.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
         "sha512": "9a791e435a8fe547b6c1df9a8af4c3dcd1ddfe567de8bbb48e07f4a7092d2cfb71e9c4d9887eedc9e191447b34cd7d2b6eb6a15cf9d79549db797c9a041b886b",
         "dest-filename": "open-b3BlbkBucG06MTAuMS4w-a9c4105243.tgz",
@@ -28541,13 +28604,6 @@
         "url": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
         "sha512": "e5be98f39b4fc5967b432b4ef81433cac5b7d47264bb6edc4489646c05da371f8175c562f8b951166557cde17a6bb242c09a72c397386fe61254899022b069b9",
         "dest-filename": "ora-b3JhQG5wbTo1LjQuMQ==-8d071828f4.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
-        "sha512": "1094373623f95e8f78c095c8cc0c8eb526f440420052eee6f2de9467d92b6f3d2f009aabf7626970afe511783dd6ae81f69106aabca491dd8442996789f0d207",
-        "dest-filename": "ora-b3JhQG5wbTo2LjEuMg==-a5a7fe4098.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -29350,6 +29406,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+        "sha512": "791581e4b073ecfa43bb83d49704f43e19d07d34099430dd3dadf9bab5783acae6d2dd00a901469fe508914de4959bf027c28f3b755b045b17aae03aa7a92a67",
+        "dest-filename": "pe-library-cGUtbGlicmFyeUBucG06MC40LjE=-39aa0a756a.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
         "sha512": "648dcb9f052fe673866d0cc3f5cda20c6eada217ae5d264fe5eb121c18e8a6c5c7e1d835f6ca2e7efa54180deea218b96a716d19bda584055d1f31fa47f12fbe",
         "dest-filename": "peek-readable-cGVlay1yZWFkYWJsZUBucG06NC4xLjA=-97373215dc.tgz",
@@ -29378,9 +29441,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/pg-boss/-/pg-boss-10.4.0.tgz",
-        "sha512": "a030cdf7c895a4b17a66f6de01fd821912712d8e59066443b1b81eb1d04f379cda4ad17922ee534bef84272c5ad37bdb4640837a273324d138d14a71245c6d56",
-        "dest-filename": "pg-boss-cGctYm9zc0BucG06MTAuNC4w-ec93881230.tgz",
+        "url": "https://registry.npmjs.org/pg-boss/-/pg-boss-10.4.2.tgz",
+        "sha512": "02db4458eb52ce7e776aff0e9c231611a9f0441be3919084d72e672eb667c2f924327959e57a560e967bb0a23f0588ef8b639589e317dfb6ab0f6002809ef9d3",
+        "dest-filename": "pg-boss-cGctYm9zc0BucG06MTAuNC4y-4f2952c6f2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -29388,6 +29451,20 @@
         "url": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
         "sha512": "6200adccc1f4a6dbd926c94b3357dfb18e04b86694d1cc785d27572d115a7bc6cf3f8752e712f5b4d077936a3f37ae1c1c9a7053b7712a58bf9d9da551ae5f2e",
         "dest-filename": "pg-cloudflare-cGctY2xvdWRmbGFyZUBucG06MS4yLjc=-3d171407cb.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+        "sha512": "ea5b305554b3b661e246d0fa23c870e2a3ff9c39b51096ca31185fdc70986aab9dedfac6cac3efec5609e67a1941d850b4ddb12678a67ccb6f42adb5a5d6f3c9",
+        "dest-filename": "pg-cloudflare-cGctY2xvdWRmbGFyZUBucG06MS4zLjA=-04007ebbd3.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.14.0.tgz",
+        "sha512": "5f058319c2d11825c047c17f00ce5b1bb43e0375a6dace907848e538a64b947dd461c82e8aa0962b259755a8394cb4c88d1ee8389518f247000da66058fc8b7a",
+        "dest-filename": "pg-connection-string-cGctY29ubmVjdGlvbi1zdHJpbmdAbnBtOjIuMTQuMA==-9434e5fbb9.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -29427,9 +29504,23 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
+        "sha512": "80ab4f9057503d4dc392ca2854b8bd2ec8d9c6bb015192296beeda571f8b579a4d8742b33f86657ae776a68f82a27af16ee5c6049e877deafa85d829201a416b",
+        "dest-filename": "pg-pool-cGctcG9vbEBucG06My4xNC4w-0d90984fa8.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
         "sha512": "e8320180141a4ca0c9cb19d768b88b47cc01a5041c196b80112911057fede8ec00f18b2a3fe8954a2a27776103cba63f76c1a4f2b87f8ed6b1de3b3935e57b25",
         "dest-filename": "pg-protocol-cGctcHJvdG9jb2xAbnBtOjEuMTAuMw==-31da853190.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
+        "sha512": "72af6c102239b34fae3d45e36f3f22a323c99e2e91cec4626f4512ebb8b92284d92b0f1f35e625544eeef05e1d1bbbc4249b5ce70743d4ad7cf65082530a964d",
+        "dest-filename": "pg-protocol-cGctcHJvdG9jb2xAbnBtOjEuMTUuMA==-be9a534a45.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -29444,6 +29535,13 @@
         "url": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
         "sha512": "7a7c5cd61d2303f6aae6848332fab25b7abcf6b6ba5c8203660097f6f90cae7cf90c54f0fcdcb72e2da5150fa9b772fa302826ff9a36a3c1d6f618898e2fb1bf",
         "dest-filename": "pg-cGdAbnBtOjguMTYuMw==-6a2885a3f5.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+        "sha512": "95d84cc73dabf1f97fe909179c10f7091f7fc60ebde284fa0d9436b3a73f448dbc3a3b523a9c673eb50218e049e3a442531716771de9ea4c3fc670c78cabda44",
+        "dest-filename": "pg-cGdAbnBtOjguMjAuMA==-a30b99c799.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -29497,13 +29595,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/picomatch/-/picomatch-3.0.1.tgz",
-        "sha512": "23712eaeb21032545cf48680667a91474e383e18760d763ee79a3bb89d15fa161901c4184ae156b1cf6ae4fbf20c751209ed50c67fe2073fbbf2cf3acd69c66a",
-        "dest-filename": "picomatch-cGljb21hdGNoQG5wbTozLjAuMQ==-65ac837fed.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
         "sha512": "33b04057a465732e6efa6ea83e100f160253cc08a85ffe81d03c72bc3968f65f3e4f79cb29badcce0d962d4cb3778e4bf11a9f50cc863f37a46ccbd7d8b764c2",
         "dest-filename": "picomatch-cGljb21hdGNoQG5wbTo0LjAuMg==-ce617b8da3.tgz",
@@ -29518,9 +29609,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-        "sha512": "786d9d593570e5bcea191ced9c7131733371b79546b04e8ec137821b77dd51ff4a06c6733b7479388208cd647e89903436d67e44355d6a813674ad5c9fa8c7e2",
-        "dest-filename": "pidtree-cGlkdHJlZUBucG06MC42LjA=-ea67fb3159.tgz",
+        "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+        "sha512": "40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec",
+        "dest-filename": "picomatch-cGljb21hdGNoQG5wbTo0LjAuNA==-f6ef80a359.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -29637,16 +29728,23 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-        "sha512": "6a04dc2a5330fe68c158e9c3ea4159b6d000187822fcdc34099da8e89a9649b325236d7d94014b6590b2a81c93b2f54026ae570391fc700e8faef051a41584b9",
-        "dest-filename": "playwright-core-cGxheXdyaWdodC1jb3JlQG5wbToxLjU3LjA=-ec066602f0.tgz",
+        "url": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+        "sha512": "7e759596351c853ae8e9188216f09705b36125cd8d8a337ba084316f0b322f46ee5893c6f39bfcd5e8651c8f5f5eb26c30d813a1f12858841e0a52a983114bae",
+        "dest-filename": "platform-cGxhdGZvcm1AbnBtOjEuMy42-1f2d8333e2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-        "sha512": "8a56108f5b3cb2bda9a4427661569d60137431bde6768f49d3043e52e0e1cd8a944704a85b89f55ece6fb3b391c200c69b2121df7b5131e4bc2a17643282d743",
-        "dest-filename": "playwright-cGxheXdyaWdodEBucG06MS41Ny4w-241559210f.tgz",
+        "url": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+        "sha512": "1c157f44983cd73e418a267dc8fcc888295857f40cb0308a532a20c07f69dcc08fe88623505bbf30072d81802f2b4a16c95f4d97033718b063003c96832755ca",
+        "dest-filename": "playwright-core-cGxheXdyaWdodC1jb3JlQG5wbToxLjU5LjE=-d27857a670.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+        "sha512": "0bca168cf47717cd729635bda393b1716cdf87a6af915c030f6558770206a93925f8e185212832a6acdfbbb74e7b840d2cbd9aa9c581988dcf32d2c82b6df797",
+        "dest-filename": "playwright-cGxheXdyaWdodEBucG06MS41OS4x-17b2df42ef.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -30589,9 +30687,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-        "sha512": "23b0088396e802be51d0516d27aac27c3f8b16c587a7cd5da25ac50fc4bbf54f6d6fc033da71ab2677273129f2b3e6e94097d1533aacf619c0f35380037842b9",
-        "dest-filename": "prettier-cHJldHRpZXJAbnBtOjMuNi4y-1213691706.tgz",
+        "url": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+        "sha512": "bfa50d8b5fb7852955beff1f49aa146e0804339544aca9a6a4603b3e5dc717c57ab8a63baef0a504e2651fac8dc10b5f4ee78d9065693affe6b562fd2f86e044",
+        "dest-filename": "prettier-cHJldHRpZXJAbnBtOjMuNy40-b4d00ea13b.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -30680,13 +30778,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz",
-        "sha512": "29c9a8d8585f0d35dd71b7c31fbe8deee0581c837173ff065bb50056e54ff48f956b7b8749eaeb9ca57a74ba2881afe087b1a5833b820abfdea257672f59ae1b",
-        "dest-filename": "proc-log-cHJvYy1sb2dAbnBtOjIuMC4x-f6f23564ff.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
         "sha512": "fbe567ecd4b85dff4d69c694f57ab751152ea991133ec7fc2f88f9fdc92169162c7cf791cb31b0fa20e316157f26bdee3664efbdd7442455a1e51d60460507f0",
         "dest-filename": "proc-log-cHJvYy1sb2dAbnBtOjMuMC4w-02b64e1b39.tgz",
@@ -30704,6 +30795,13 @@
         "url": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
         "sha512": "033c33be5f741da174682cf526b0dd5d0ca415a91248d3da3e8899f5f9b9a8920c1e2a036448bb380751c129baad2a0fb58dd0bad9e6dcbee882683775cfb06d",
         "dest-filename": "proc-log-cHJvYy1sb2dAbnBtOjUuMC4w-35610bdb01.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+        "sha512": "886f866257517f6050d140d401de8943f470cda432ea65e6b24fc8ce56326a5e00e12345c39e0c787e3fb4b905e08e56a161bd490c2ea96cd2f7d8da1501c1b9",
+        "dest-filename": "proc-log-cHJvYy1sb2dAbnBtOjYuMS4w-9033f30f16.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -30904,9 +31002,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/prosemirror-search/-/prosemirror-search-1.1.0.tgz",
-        "sha512": "867188365ad1b3e4adeac71a1788681a247c6fb5747df75dcef3bfcf2f8e37c470bd58a77cb938ad5b2e4b3b4b36d860bdf1362c0394e1b96c3ebef2a1ea0b39",
-        "dest-filename": "prosemirror-search-cHJvc2VtaXJyb3Itc2VhcmNoQG5wbToxLjEuMA==-2988194d37.tgz",
+        "url": "https://registry.npmjs.org/prosemirror-search/-/prosemirror-search-1.1.1.tgz",
+        "sha512": "d5d6f16c5d586253fd99826715b7dd39bf7e4537451de67f1b0804c870f88e0f6ccc0f04562b4c0a77d750160b985ba7e74d0531906446f715d20a790692f0e1",
+        "dest-filename": "prosemirror-search-cHJvc2VtaXJyb3Itc2VhcmNoQG5wbToxLjEuMQ==-68e725c7d8.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -30925,9 +31023,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.5.tgz",
-        "sha512": "44f0d00b120384805bd68dfac71c2c69e02f8af3bc54b25c801b7398ec10eb86ccb6c545879492b89e9d592c4ed54b074e24d73c28109b73c326dee9e8838b6f",
-        "dest-filename": "prosemirror-transform-cHJvc2VtaXJyb3ItdHJhbnNmb3JtQG5wbToxLjEwLjU=-958b738082.tgz",
+        "url": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.11.0.tgz",
+        "sha512": "e08ec27b82a9ca05dbf5b9223d2de14c49387521e8adf470f2e234a44f0887194ad865ecaafe6d200ec9512c6d4aeeeef003d5393b5b501c539a71c8c5590827",
+        "dest-filename": "prosemirror-transform-cHJvc2VtaXJyb3ItdHJhbnNmb3JtQG5wbToxLjExLjA=-d6d8754e7d.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -30942,6 +31040,13 @@
         "url": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
         "sha512": "bed2bff786a4c6c4cc85ed3f71b7e947eb323eeb3372ec21a958c9ab6e82b8d0e01468faf36a1105738fe4c269bf6afb26d13c32c89ea4622abef3930709f6bc",
         "dest-filename": "proto-list-cHJvdG8tbGlzdEBucG06MS4yLjQ=-9cc3b46d61.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+        "sha512": "44924f4d3a6f15f1dc58b9086b624558ae17bed4b34b4c845839ae9ea1d7962d61dc99646dc4195c365d716c6ff892b75ec979fd41433d9d221a6ec301e9e063",
+        "dest-filename": "protobufjs-cHJvdG9idWZqc0BucG06Ny42LjQ=-eb6898f3a1.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -30967,9 +31072,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-        "sha512": "0fece439109b03d7f5b5d5912b445a091dc63efe7470cc5caf3e17f24e4b4d2503d43930e3b98a24465036e9c8b514e45b082d6944a8d515454481bd65788562",
-        "dest-filename": "proxy-from-env-cHJveHktZnJvbS1lbnZAbnBtOjEuMS4w-f0bb4a87cf.tgz",
+        "url": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+        "sha512": "709fa81d35b554011af1c26c96099466b73eb2344a8002a5dd9cac7baf8f577f2165efd5e99d784db0ae5dc6a7f45f60865cf842b16bd9cf764cd17cd949181c",
+        "dest-filename": "proxy-from-env-cHJveHktZnJvbS1lbnZAbnBtOjIuMS4w-fbbaf4dab2.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31296,9 +31401,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-7.4.0.tgz",
-        "sha512": "209a2978f18ee879cc59575e2c28a19f15d9d16096d26c57894e4b1376d9d34187112b02680be00fc84dfc04c825e6619eb55d53971f4724b5b95eb7566738ce",
-        "dest-filename": "rate-limiter-flexible-cmF0ZS1saW1pdGVyLWZsZXhpYmxlQG5wbTo3LjQuMA==-8501212494.tgz",
+        "url": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-9.1.1.tgz",
+        "sha512": "8a6c458f33c29af0cb31eedddadb2089242fb39108d9f23d48dca69ac9407ceab39d986c67e3ea6c88c860aa6e49b777a4aa2f47568c1b8eea7c22c83bf69d56",
+        "dest-filename": "rate-limiter-flexible-cmF0ZS1saW1pdGVyLWZsZXhpYmxlQG5wbTo5LjEuMQ==-3acdd92f9e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31485,6 +31590,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/react-loadable-ssr-addon-v5-slorber/-/react-loadable-ssr-addon-v5-slorber-1.0.3.tgz",
+        "sha512": "1977e1f552f0079111682b14e9150b87bb647a6797d7968d87ac2e30406d7ddc8c6bb7c51bc4d7ae15e5c754a810ad93cbf97a5c8933cd82109b26965b726075",
+        "dest-filename": "react-loadable-ssr-addon-v5-slorber-cmVhY3QtbG9hZGFibGUtc3NyLWFkZG9uLXY1LXNsb3JiZXJAbnBtOjEuMC4z-9730c08c87.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/react-motion/-/react-motion-0.5.2.tgz",
         "sha512": "f6add802f1e85225a53f770ad2ffb0d4de59db71d7323e0817862ebe3bd67a05aa34f7cb5ec38113f57b52f406a57c4714a45041c35c550137d60f5207feaa81",
         "dest-filename": "react-motion-cmVhY3QtbW90aW9uQG5wbTowLjUuMg==-a63229a09c.tgz",
@@ -31499,9 +31611,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-14.1.1.tgz",
-        "sha512": "9571697ba0c99b36d05cd2d6c653073f6c6e4d4e60c2b280bc8f1d08066e111856f5e3974ae6ce4087ac93d948067b22f69235f4632b729244bece0044f4589b",
-        "dest-filename": "react-native-device-info-cmVhY3QtbmF0aXZlLWRldmljZS1pbmZvQG5wbToxNC4xLjE=-560c5f8d99.tgz",
+        "url": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-15.0.2.tgz",
+        "sha512": "75def57971b69770b0a7ae88bca35a74c4c1f1f854dcf123c9575d23deec61a9fe0f86e02005268060e16d2385bc77066af92c6f6535ee489061a0e22b658ada",
+        "dest-filename": "react-native-device-info-cmVhY3QtbmF0aXZlLWRldmljZS1pbmZvQG5wbToxNS4wLjI=-9f945a16bd.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31520,9 +31632,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
-        "sha512": "e014db0db4664bb88f76160b45ccf73c6148a45241c0d660f60e368b06b63fa14ebfdbd98ffc4973aefc4595e72cd673774a9ded0dc2085e9877e094d9ea1729",
-        "dest-filename": "react-native-get-random-values-cmVhY3QtbmF0aXZlLWdldC1yYW5kb20tdmFsdWVzQG5wbToxLjExLjA=-eb04833ce2.tgz",
+        "url": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-2.0.0.tgz",
+        "sha512": "c31eff68faac508896b06df90fe32c50977c8a3f7a7b724a75d92549dadd654ae1793c7cf603edcf7436ca5f649c102b8f9bb6e82976dd3f3c6a2f90d2fca975",
+        "dest-filename": "react-native-get-random-values-cmVhY3QtbmF0aXZlLWdldC1yYW5kb20tdmFsdWVzQG5wbToyLjAuMA==-f55218ac97.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31541,9 +31653,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-localize/-/react-native-localize-3.6.1.tgz",
-        "sha512": "d24545521f1359e87ef29d77c952038db71dc51d9939f3c114d718fd5061ff7fe0f0a7ef5f2c18fd72640ae095ad7e5d08bba6322dda5e6cbe32624dcb821a61",
-        "dest-filename": "react-native-localize-cmVhY3QtbmF0aXZlLWxvY2FsaXplQG5wbTozLjYuMQ==-1f693ad3fa.tgz",
+        "url": "https://registry.npmjs.org/react-native-localize/-/react-native-localize-3.7.0.tgz",
+        "sha512": "e8e871fb3673c9c0bace135504633fbb553e3ba5b0dbd60816c79ec97aac29c3bfa537e32dc744e34214245e12555c2b761d3420c270cbdd078cb19469ea8aed",
+        "dest-filename": "react-native-localize-cmVhY3QtbmF0aXZlLWxvY2FsaXplQG5wbTozLjcuMA==-e8ec5e179a.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31555,16 +31667,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.33.2.tgz",
-        "sha512": "6657ce7ba69b383787bff7997fc3f179292bc4852110a85aea3680000f685f2ec8e953ebec57f8754b00ab7732177917d0beaab760e1f67cc3d8d752b03c06a4",
-        "dest-filename": "react-native-nitro-modules-cmVhY3QtbmF0aXZlLW5pdHJvLW1vZHVsZXNAbnBtOjAuMzMuMg==-fece339c9f.tgz",
+        "url": "https://registry.npmjs.org/react-native-nitro-modules/-/react-native-nitro-modules-0.33.9.tgz",
+        "sha512": "04cf42e660866188eb73c0835996746a72d653f9271f6c5a12e173bf3a20293396e9fce04ba9a6b0274cdedcbe02122624d498c0ad7d0cbac76aac27aebc04cf",
+        "dest-filename": "react-native-nitro-modules-cmVhY3QtbmF0aXZlLW5pdHJvLW1vZHVsZXNAbnBtOjAuMzMuOQ==-4ebf4db46d.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.14.5.tgz",
-        "sha512": "79a207e5b5108c9fe6626e00908e9c69a8b273b05c1c3c17e82a8d0e2e912317f17d6c513ac1e9965d6806ec27fdc16f927bc0f2e10092a2e4fefcd58a123701",
-        "dest-filename": "react-native-paper-cmVhY3QtbmF0aXZlLXBhcGVyQG5wbTo1LjE0LjU=-8e09897429.tgz",
+        "url": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-5.15.3.tgz",
+        "sha512": "184c8d4e65849486609d8c34f408e308dba9458cc298fefdb80032192c82114673eca073d70b49702d30554928cd1d519f73cafed77ff4b951ebe175873998bc",
+        "dest-filename": "react-native-paper-cmVhY3QtbmF0aXZlLXBhcGVyQG5wbTo1LjE1LjM=-6e34e04f4c.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31590,9 +31702,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-quick-crypto/-/react-native-quick-crypto-1.0.19.tgz",
-        "sha512": "68859454484642ad0e71cf260e4001a8da60e7f9d91581eba6f8d60eb4941c4d61b809c60f132a94b3f734cf1ac666bf756886ff54dff8291be209650792cc95",
-        "dest-filename": "react-native-quick-crypto-cmVhY3QtbmF0aXZlLXF1aWNrLWNyeXB0b0BucG06MS4wLjE5-73a6ac9e3c.tgz",
+        "url": "https://registry.npmjs.org/react-native-quick-base64/-/react-native-quick-base64-3.0.1.tgz",
+        "sha512": "12350fd94ed6a8a9a5326a18ed71b21e89b2f1b334ab8fb208309183865ecd0eb379d611c1cef2564e15d8efe249fb4a68b13386e5bdf25a723cc764d623c75d",
+        "dest-filename": "react-native-quick-base64-cmVhY3QtbmF0aXZlLXF1aWNrLWJhc2U2NEBucG06My4wLjE=-9810adfd36.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-native-quick-crypto/-/react-native-quick-crypto-1.1.4.tgz",
+        "sha512": "723e5d1985178bde9613d54f56fed33491d72ab182abfd1b94c29be7de6c08c139b815fa69ab97a8c32a225a440c79b75d8f2e29e738a6d010b41befce044b52",
+        "dest-filename": "react-native-quick-crypto-cmVhY3QtbmF0aXZlLXF1aWNrLWNyeXB0b0BucG06MS4xLjQ=-6151263a87.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31604,9 +31723,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
-        "sha512": "e171aa30d8f9aa3513632c09aa975667d206f238244b7874eac7d58dfc39c994197d69d11577338b41a763217209cd84069b3fa859a8087f1f7b3fff5ae99d56",
-        "dest-filename": "react-native-safe-area-context-cmVhY3QtbmF0aXZlLXNhZmUtYXJlYS1jb250ZXh0QG5wbTo1LjYuMg==-880d87ee60.tgz",
+        "url": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.7.0.tgz",
+        "sha512": "ffdfccb50cfc383a618ec2dd67e199008702fd1b68a96f4479285fed4be77e09bfa7362b27be72dcf57f275c2e015d53e43c9ee7282ae04016db446806ad0005",
+        "dest-filename": "react-native-safe-area-context-cmVhY3QtbmF0aXZlLXNhZmUtYXJlYS1jb250ZXh0QG5wbTo1LjcuMA==-9f5d3469c1.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31618,9 +31737,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-share/-/react-native-share-12.2.4.tgz",
-        "sha512": "1fdabd957701df6da330c310df1020d9016ec768339c9cf3b5c367c9c2b88aa2ff5e30c650b7ff31691dc015d47c412197ac9d9c69a13fa86e44c4588b22069e",
-        "dest-filename": "react-native-share-cmVhY3QtbmF0aXZlLXNoYXJlQG5wbToxMi4yLjQ=-5be965fca1.tgz",
+        "url": "https://registry.npmjs.org/react-native-share/-/react-native-share-12.2.6.tgz",
+        "sha512": "2bd8d909069322a48d1b7ee4315ca0535adf9553099b68348a4b259db6e643b120b1c918a70ee2a5e3f2a74d44eb8846f87ad6365fb3f599c558b082e87f938b",
+        "dest-filename": "react-native-share-cmVhY3QtbmF0aXZlLXNoYXJlQG5wbToxMi4yLjY=-fdea43120c.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31632,9 +31751,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.1.tgz",
-        "sha512": "6540f5c707371f0a3870e98e2ee9a3255a1cee511ff684059479cb9a071c2c2d7d7cd9ba2d511db41f829e2a7a8048b43c6df07ef573b2456212daf24903fc17",
-        "dest-filename": "react-native-svg-cmVhY3QtbmF0aXZlLXN2Z0BucG06MTUuMTUuMQ==-3a5dbbee0c.tgz",
+        "url": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.5.tgz",
+        "sha512": "2f8828e6303e196bad749fc9b9cb8ddb472301b320d4798cb403fec19fb724b09fe897746e15d01f172244ffc0426fc596b20467090c7073593fe15702289cd3",
+        "dest-filename": "react-native-svg-cmVhY3QtbmF0aXZlLXN2Z0BucG06MTUuMTUuNQ==-d5ffbb5550.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31660,9 +31779,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.0.tgz",
-        "sha512": "361d77c4a6565b7e42d1d6ceb240fb397d359d041abcecc76c2c3d5e86666abe1e5c2a3b02fad82748e551f455548273a883711e5a440982dd980745b25f710c",
-        "dest-filename": "react-native-webview-cmVhY3QtbmF0aXZlLXdlYnZpZXdAbnBtOjEzLjE2LjA=-dc3d84c478.tgz",
+        "url": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.16.1.tgz",
+        "sha512": "21fd1e1e1a0474e603707b17fb1045c0731b58118ad41bc60d00d0755930b522178aad6e8aa8e4a5654fdae4356acf782740b3bc513d3d4343ba1897d19eae6f",
+        "dest-filename": "react-native-webview-cmVhY3QtbmF0aXZlLXdlYnZpZXdAbnBtOjEzLjE2LjE=-3b97550ccc.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -31835,13 +31954,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/read-config-file/-/read-config-file-6.3.2.tgz",
-        "sha512": "33cd25a428e713a5adeb36fdf03a16f161d1d3d9f3312a6ef171ed3e48931eb279033f42c9b7de4214c9f03eec69e047a4684b3c857203c95c2fa66674ac18e9",
-        "dest-filename": "read-config-file-cmVhZC1jb25maWctZmlsZUBucG06Ni4zLjI=-c3a6444105.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/read-installed-packages/-/read-installed-packages-2.0.1.tgz",
         "sha512": "b7e7c93853986992230694d5c6257c324b7bc90cb2e04e8c4abae7b791663dde1e9d8be953ff436068ab0e63755d0c247deb9622133f8aed2ddab9ba892af408",
         "dest-filename": "read-installed-packages-cmVhZC1pbnN0YWxsZWQtcGFja2FnZXNAbnBtOjIuMC4x-b09ac463a5.tgz",
@@ -31975,9 +32087,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
-        "sha512": "ca36af10276a799dc62d736045781e404773f5fbc30e434ac879db1d116d3abeff2dc7e005c99cb7bb7f113f876824ea7e1d3a3b3a00c6b90dfc87e324155efa",
-        "dest-filename": "readable-stream-cmVhZGFibGUtc3RyZWFtQG5wbTo0LjUuMg==-01b128a559.tgz",
+        "url": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+        "sha512": "a0818699ca532f03e06bc067ebf67be5255a1f5cf9754badda26d2c80315866520816a660e7d9d6a90749fb7fc9f0692891b5ea40b1f2727d720ee4309500e0e",
+        "dest-filename": "readable-stream-cmVhZGFibGUtc3RyZWFtQG5wbTo0LjcuMA==-bdf096c8ff.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -32598,6 +32710,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+        "sha512": "bc78dc6363250084c9842d1e443fd5bfc565826bbd49ddcb5fdcd9bed1b353964899d4cddfe77a7bfe269d3c95f2f11bc9fd6c80d22b5b185696bcace763a410",
+        "dest-filename": "resedit-cmVzZWRpdEBucG06MS43LjI=-0fc470cb32.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/reselect/-/reselect-4.1.5.tgz",
         "sha512": "b95765cfc27b38ef804a9058a33d59ca9831d0a6ac098db41fe37c243d77a1432d3ef48742eb1cac7a29e0a6d7adbb0171d07d0ecee554aede4640487cee37bd",
         "dest-filename": "reselect-cmVzZWxlY3RAbnBtOjQuMS41-eabf06f34e.tgz",
@@ -32804,13 +32923,6 @@
         "url": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
         "sha512": "97eb1279fcc7a63e6a8a6845484e5af27b9f65800cdec05254c00fb589260bee041f66a7486684317483d22cd141bbbd9dfc90f72e49ad59a9ec4f2866b523bc",
         "dest-filename": "restore-cursor-cmVzdG9yZS1jdXJzb3JAbnBtOjMuMS4w-f877dd8741.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-        "sha512": "23d7cf5d4f6078ef5b1ceb7da471ce84e9187ab20cb2655a581d2b036008f44461ffec7f8bb315e4728136b83e9633b97a83d580272716e46327db87e88ff77a",
-        "dest-filename": "restore-cursor-cmVzdG9yZS1jdXJzb3JAbnBtOjQuMC4w-5b675c5a59.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -33123,9 +33235,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/samlify/-/samlify-2.10.2.tgz",
-        "sha512": "cb9b35707c1c96ac0ff21ecad968fd49f3f5abed52f7e8ebb393807a06132c08ae162ee70efb8aa9b8972e6513bd83cca731dc5fde304d8dbe0fad388e04cabc",
-        "dest-filename": "samlify-c2FtbGlmeUBucG06Mi4xMC4y-2f46e2b172.tgz",
+        "url": "https://registry.npmjs.org/samlify/-/samlify-2.13.1.tgz",
+        "sha512": "bdd62bff3a210c605b7d6354e26884cdcd639963ad90bc923d589aa42ea77c692ff4ac732eae1494690acabcb3c0bc388d595993cf11c3ddc7682455a5efadfa",
+        "dest-filename": "samlify-c2FtbGlmeUBucG06Mi4xMy4x-1dbbe6f1ee.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -33144,9 +33256,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-        "sha512": "7c3cf5cc9a5de46c9ca6b01bbb84363d5fd1a6bb11b4a0bfd33f36cf424b81dcad99cab4fae8c96c9ff4f5b3c60f108b90a637369e5c44039c5a25642d725446",
-        "dest-filename": "sass-c2Fzc0BucG06MS45Ny4z-707ef8e525.tgz",
+        "url": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+        "sha512": "9205b5dcce780d407b22c2113392ef264365a47f9684ca68a1471a5861404641754dcf36bfd9885a409b0987fe301be92140527923938a5a598c43ebd95604e9",
+        "dest-filename": "sass-c2Fzc0BucG06MS45OS4w-93f9d5c3b3.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -33427,6 +33539,13 @@
         "url": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
         "sha512": "49db0a32b23d4dd823770794491f4cc1e1c0e0427c6311e7f0315a0e2b2f85595439ee01175b4b0fb1808f4948a96565f9d3dbfeb131af406d6f2e65a109b6d1",
         "dest-filename": "semver-c2VtdmVyQG5wbTo3LjcuMw==-8dbc3168e0.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+        "sha512": "bc5282d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894",
+        "dest-filename": "semver-c2VtdmVyQG5wbTo3LjcuNA==-26bdc6d58b.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -33774,13 +33893,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/short-uuid/-/short-uuid-5.2.0.tgz",
-        "sha512": "dbdebf3738b80e600d87dde2601c13e0da18449b879ca13379fae449a8106d31ff03a353681ebc8523c38e6e4895b239771f455dd9ada8f723e8de47f823e6eb",
-        "dest-filename": "short-uuid-c2hvcnQtdXVpZEBucG06NS4yLjA=-9915e92c51.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
         "sha512": "1422c7b510ff827a428821c48892cec1d9853fec330a60c491cf72ecdb18c5e178bbb06db27d59bb0830246c4898898789c240acb3f8474c97e1cd8a0ab32b4c",
         "dest-filename": "side-channel-list-c2lkZS1jaGFubmVsLWxpc3RAbnBtOjEuMC4w-603b928997.tgz",
@@ -33963,13 +34075,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-        "sha512": "a8c08c7e1634e347151d3e372bd045ca0a986d43c564a1ce83b2bbde6b5358945bf29c8fddfcdfe08c5de52cdd10943a311520fd606738bc60859b4a2aeac435",
-        "dest-filename": "slice-ansi-c2xpY2UtYW5zaUBucG06NC4wLjA=-4a82d7f085.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
         "sha512": "6d28929e067f8d6797f7706a78801b226c936c48a18b3730363168454218fd3d70590b1fb26d95c356a03caca55ef41353b880486747872a9196a4337f3f87b6",
         "dest-filename": "slice-ansi-c2xpY2UtYW5zaUBucG06Ny4xLjA=-10313dd3cf.tgz",
@@ -33987,6 +34092,13 @@
         "url": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
         "sha512": "87ecfb1ca1d85e3eb0254f809d2ffe207f1487d7dd717d4bae1835fd531d7fd3f0a0141715c5e201db32dad48ad0fea02b024b5e9d36afdd1a8540aa1e4f6baf",
         "dest-filename": "slugify-c2x1Z2lmeUBucG06MS42LjY=-d0737cdedc.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+        "sha512": "bd9eeb7de7a166e8bbc10b38dfc25705c9182e420875f1ce5ec6951143324b97c7a35e3cde5d5b31da3410349661c958d3264a14e8a90f2e0a1ee2aceacb2f76",
+        "dest-filename": "slugify-c2x1Z2lmeUBucG06MS42Ljk=-101599a775.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -34397,6 +34509,48 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/sqlite-vec-darwin-arm64/-/sqlite-vec-darwin-arm64-0.1.9.tgz",
+        "sha512": "8d2b19a44e3639f06418bfc8b7225354253097aa3a29add4e6b7388fe5010c84330b5ba549228c12140bb61b0e9c5fcc7407f532e02462191d2a699c8da21942",
+        "dest-filename": "sqlite-vec-darwin-arm64-c3FsaXRlLXZlYy1kYXJ3aW4tYXJtNjRAbnBtOjAuMS45-10.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sqlite-vec-darwin-x64/-/sqlite-vec-darwin-x64-0.1.9.tgz",
+        "sha512": "283955caa413ee99ce854d72981f60b3b74c6d2a1598a1e2b53fa4d7fc648daadc5fc6c1a8fc56ac694afd1f82e5699691fbd6c32ab915f5df88160206ce8f94",
+        "dest-filename": "sqlite-vec-darwin-x64-c3FsaXRlLXZlYy1kYXJ3aW4teDY0QG5wbTowLjEuOQ==-10.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sqlite-vec-linux-arm64/-/sqlite-vec-linux-arm64-0.1.9.tgz",
+        "sha512": "e705d527d73d911e021e6ff056a5dbfd1f975074dda59e2759b3c7952fa073da901551ecf762a6e1b3e708a5f8aed70f333bcd8acf92233309475482130a6e53",
+        "dest-filename": "sqlite-vec-linux-arm64-c3FsaXRlLXZlYy1saW51eC1hcm02NEBucG06MC4xLjk=-10.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sqlite-vec-linux-x64/-/sqlite-vec-linux-x64-0.1.9.tgz",
+        "sha512": "c37b421fcc4ad9f8a75bc7d027f9bcbaa2a8757519f4a02e01aaf6508873e011c82dfa44d1633f31318245f6bb46361bad88a6e4bba4de0baf30e188ed3ec940",
+        "dest-filename": "sqlite-vec-linux-x64-c3FsaXRlLXZlYy1saW51eC14NjRAbnBtOjAuMS45-10.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sqlite-vec-windows-x64/-/sqlite-vec-windows-x64-0.1.9.tgz",
+        "sha512": "cb7804232cbfd7b6ead9014f40e58b13af13616711664050540d972eb4cf1cd4cea79e71262fc104198e9b8d2d54c0cc8ed3fe125a64e940545dd6aafb8e9bd1",
+        "dest-filename": "sqlite-vec-windows-x64-c3FsaXRlLXZlYy13aW5kb3dzLXg2NEBucG06MC4xLjk=-10.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.9.tgz",
+        "sha512": "2fb5c959120136f47d3b9faf875150f881a487fdc3d80cd592c5b981db64dbc9bbf07cbcb24143d29a9178a1f5629d3f05429119c7df80abf23bf10e379257a4",
+        "dest-filename": "sqlite-vec-c3FsaXRlLXZlY0BucG06MC4xLjk=-05a8bbc54e.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.6.tgz",
         "sha512": "a256245a828554d49249036fc5551f8e255bcf762d0704c98fe99f579ce91e6a96dec10bc7609fe1009d8ab31e961339661f8a0d568a8101ea0b1aea8961f26f",
         "dest-filename": "sqlite3-c3FsaXRlM0BucG06NS4xLjY=-343ffefb69.tgz",
@@ -34435,13 +34589,6 @@
         "url": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
         "sha512": "f7ba92873cb5022cb1bcf34890b5a81ae6bbc68433ccf8d0d07007e01d2b58aa3b499e944ae3dcad488016bc2cd141fc46b6d69a0ab72cc4ce6e13c81db6c179",
         "dest-filename": "ssri-c3NyaUBucG06OC4wLjE=-fde247b710.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
-        "sha512": "a39ed6727eba8cc42f7c71b516561b59e6565bf7476612578e921c4df5e5757124e67cf9952b4fa3798ad0e2507c647745b65495b2127b16e58e4273b848fff1",
-        "dest-filename": "ssri-c3NyaUBucG06OS4wLjE=-7638a61e91.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -34645,6 +34792,13 @@
         "url": "https://registry.npmjs.org/streamx/-/streamx-2.15.0.tgz",
         "sha512": "1dcc58ea77068e39251acd71b0fd5a47bd4835872c5c525eb79094d421ea8a14362799ceb1b7783a38231cee36c3fe1036ff6065bdc1b9e57e571a24e692c45e",
         "dest-filename": "streamx-c3RyZWFteEBucG06Mi4xNS4w-c4d311a4b7.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/streamx/-/streamx-2.26.0.tgz",
+        "sha512": "56f346d4aef63e8ff1c09cf16459d9fbe4dbaefe25c12a6db1b905bb35c2240619bc22b99e7c6cbd753a6a3aa4bfb721ca2235634617ab6261f08cbc63b345fc",
+        "dest-filename": "streamx-c3RyZWFteEBucG06Mi4yNi4w-77cdc5f2e0.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -35258,13 +35412,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.2.0.tgz",
-        "sha512": "eac5c4cd5e7e2398fc066abdfef52984644cfd124d4fd48251124b8f07ce839d61791b60b86583cdc6819600332a141ad0454da4f10acd0b81c19f12f1668279",
-        "dest-filename": "supports-hyperlinks-c3VwcG9ydHMtaHlwZXJsaW5rc0BucG06Mi4yLjA=-a63f2acba5.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.3.0.tgz",
         "sha512": "469b00665a56703c0e3d0036d9a087e09d2decbf09980bec0b17ce484c26edc42cdcbb21377e9069393077bd039c13970d61acb30d9e52873c09a4564f45ee9c",
         "dest-filename": "supports-hyperlinks-c3VwcG9ydHMtaHlwZXJsaW5rc0BucG06Mi4zLjA=-3e7df6e9ea.tgz",
@@ -35349,16 +35496,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
-        "sha512": "6385fdceaac27ed52131e1f6129b5248445d54ab7f9c47628d339a7060fff7b10a8e143f42cf114e510600148934d37c95a73d921787f9a7fbc809045a582778",
-        "dest-filename": "table-dGFibGVAbnBtOjYuOC4x-512c4f2bfb.tgz",
+        "url": "https://registry.npmjs.org/taboverride/-/taboverride-4.0.3.tgz",
+        "sha512": "420302c15c3045e53d85d5fd074a36b27349b4fbad8a323f5898601b10bdd677e2f507fd36e1bdd34182169bf446fff58336cbc2fbf2178c60f8e03b2a1d82b8",
+        "dest-filename": "taboverride-dGFib3ZlcnJpZGVAbnBtOjQuMC4z-8e165df6ed.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/taboverride/-/taboverride-4.0.3.tgz",
-        "sha512": "420302c15c3045e53d85d5fd074a36b27349b4fbad8a323f5898601b10bdd677e2f507fd36e1bdd34182169bf446fff58336cbc2fbf2178c60f8e03b2a1d82b8",
-        "dest-filename": "taboverride-dGFib3ZlcnJpZGVAbnBtOjQuMC4z-8e165df6ed.tgz",
+        "url": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+        "sha512": "c84158ad586877e85d372c7b8390679246f41bab22f0726eacea0e1200bc07f3b4b972c795a7b2ffae4a46fe9cb9604d84180728044e56973b43262a1398059e",
+        "dest-filename": "tagged-tag-dGFnZ2VkLXRhZ0BucG06MS4wLjA=-e37653df3e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -35440,9 +35587,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-        "sha512": "a898fad025edec853515fc9cdcd24c8e1e8492e0857a3e3acd4a89e09ee9a9895387277d6ced1705399c388852cd925559fb0b92cd3e9e57bf8f9dfc6005bd45",
-        "dest-filename": "tar-stream-dGFyLXN0cmVhbUBucG06My4xLjc=-b21a82705a.tgz",
+        "url": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.9.tgz",
+        "sha512": "c898ec823b3b3d543153c0d0201ec84a5d8ac1af06b5cacb12adc2ef5edc6f17f86411b49dbdd92b9eed6b5b5a6b5a2be0f36471c021bb1b89d5b1b4f268d5aa",
+        "dest-filename": "tar-stream-dGFyLXN0cmVhbUBucG06My4xLjk=-dc848a5e8e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -35461,20 +35608,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tar/-/tar-6.1.15.tgz",
-        "sha512": "ff32adf54ca7827c484ff100198bb168c6203882623fcd5a6fd65f9082eae2834b3c55f9d2ac989aeee3463f6a797a319891e31a56c7d3e726daecb5582b35d0",
-        "dest-filename": "tar-dGFyQG5wbTo2LjEuMTU=-4848b92da8.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-        "sha512": "0d9e323914f0adb4e3ffb31962adb0fbf645748e8e67f7fd4851d1fbbd6021551984e40f1f35422e9bd19cf83268ca5f5b1c64ff838dbdadc6412c8d20a46fe8",
-        "dest-filename": "tar-dGFyQG5wbTo2LjIuMQ==-bfbfbb2861.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
         "sha512": "e52ed56bc84a7d5ed6e54ea0dda6315e694fa19540c14332f4038ac85d9f56e65ad940f7a998e0e7bf0eacb46df0f70d3753e579568bff9ff26004cd2f420253",
         "dest-filename": "tar-dGFyQG5wbTo3LjQuMw==-12a2a4fc6d.tgz",
@@ -35482,16 +35615,30 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
-        "sha512": "ecdcb1ad313802787c926f22132ee8d1060fb3ed092814e3e596aa1e0e81dfd7ab2e0d2a6173770628ed4a1c1bb0d4af43e2cdef9f8a57e0b8411fdfe86c27a6",
-        "dest-filename": "tar-dGFyQG5wbTo3LjUuMg==-dbad9c9a07.tgz",
+        "url": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+        "sha512": "b4e1bfec6c97a457af857561f2338f26b9ad469393b18a9422455d568a196094bfcfc5a17d0517f112482e67ae24d8a7180312bb5bde06be1ab121c5b79fe19e",
+        "dest-filename": "tar-dGFyQG5wbTo3LjUuMTM=-2bc2b6f034.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tar/-/tar-7.5.8.tgz",
-        "sha512": "498901b4af7dbb4c976be2162f4251cf3725ed1c4da6f5ff534f19fbc0ca9f2b1f9e8eccfae1319d3647f0af951a04a17f6a853cab5b36bf50065f27ed604fe9",
-        "dest-filename": "tar-dGFyQG5wbTo3LjUuOA==-5fddc22e0f.tgz",
+        "url": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
+        "sha512": "77318ad1ba15942e16e5016e40dd441529776c80d8b24ed38f8d14e9e2019cada4ffc9a5ed36796a06c8e63e7eaa7a1570003eacdb419a5f121222f166936a45",
+        "dest-filename": "tar-dGFyQG5wbTo3LjUuMTU=-b4cb6acd82.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+        "sha512": "e0b7845a5f7ab709d2d90ec1cf8306aa06b32ea3be84937adc66715e822a8754f75707980fdf7b81b53522d36c41a7eaa974d7779585c8575178bb70bd104d8b",
+        "dest-filename": "tar-dGFyQG5wbTo3LjUuMTk=-0b06a0917f.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tar/-/tar-7.5.2.tgz",
+        "sha512": "ecdcb1ad313802787c926f22132ee8d1060fb3ed092814e3e596aa1e0e81dfd7ab2e0d2a6173770628ed4a1c1bb0d4af43e2cdef9f8a57e0b8411fdfe86c27a6",
+        "dest-filename": "tar-dGFyQG5wbTo3LjUuMg==-dbad9c9a07.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -35513,6 +35660,13 @@
         "url": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.2.tgz",
         "sha512": "97b6abf252d40f75d2d55da57e826508169ea1a5a8ff6c5f62df3584ced596f47846b31516a7e6cdf84b564e348406f7ebcba2b637b980fb4144bd66fc31af2c",
         "dest-filename": "tcp-port-used-dGNwLXBvcnQtdXNlZEBucG06MS4wLjI=-bbacbcbe15.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+        "sha512": "79813a88423ad8d8b51fca086bb2a50d4eae401b6aaf811a8e78b7c17eeba5f5c3f32b05c7ccf4f9dae2f8a5843d6a41b315dfc6ee7cc7fd23bd3553d5e90e4a",
+        "dest-filename": "teex-dGVleEBucG06MS4wLjE=-36bf7ce8bb.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -35587,13 +35741,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/terminal-link/-/terminal-link-3.0.0.tgz",
-        "sha512": "7e514bde6e30ba2c667fa21f84525dd583e22e232ec4473cb8744cd5bbb321e64f9b6d80bb6a43a8125081da3b9f559f3d4d4e3451afed80f0a450661c617a96",
-        "dest-filename": "terminal-link-dGVybWluYWwtbGlua0BucG06My4wLjA=-85a78ae50a.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.0.tgz",
         "sha512": "2cf222b22dce978721c0068f3fcb68509dcbe2a08cd46d306a8ecbdea36fe7b0eb7b3c63ebe544cb24a93f0e01d4748ed8483f84363f30d1795e2842028aa7b1",
         "dest-filename": "terser-webpack-plugin-dGVyc2VyLXdlYnBhY2stcGx1Z2luQG5wbTo1LjMuMA==-b5a2f97323.tgz",
@@ -35657,16 +35804,16 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-6.0.0.tgz",
-        "sha512": "d509dc9bff6828cef182b417657341f8d461d7daa25c687196b47c13015b2b949a51b3d99d2e4e32d3ff821b6a7dddb786caf566f65b6637ae00670cc5dfe8a0",
-        "dest-filename": "tesseract.js-core-dGVzc2VyYWN0LmpzLWNvcmVAbnBtOjYuMC4w-ba56c733f7.tgz",
+        "url": "https://registry.npmjs.org/tesseract.js-core/-/tesseract.js-core-7.0.0.tgz",
+        "sha512": "5a7347e75f0dce66d2abdce04cf7a817c73ec668a54bcac5225d5829b93fa6dbae73ba7a70b3442cdb8f033726b18c38e7471ae9b2daf23dedd1502dab8df957",
+        "dest-filename": "tesseract.js-core-dGVzc2VyYWN0LmpzLWNvcmVAbnBtOjcuMC4w-6eab7ecb46.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-6.0.1.tgz",
-        "sha512": "fec3ef32fac2b60c673510a36d361bafb051bb4c9f583b0c650d9afd3e5a37f2f5b7cc1440dead4d6bfaa7a170ce9a04040d23acdd940f6497e1040545da036c",
-        "dest-filename": "tesseract.js-dGVzc2VyYWN0LmpzQG5wbTo2LjAuMQ==-94f9b6a2e1.tgz",
+        "url": "https://registry.npmjs.org/tesseract.js/-/tesseract.js-7.0.0.tgz",
+        "sha512": "7b13c191dfb3fb033506e324c7f063bf8dce78b07184be64296b33ffd258f835dc5dd8818e201c874578f50477a0026a09a2f9a94444d2fc7d128f86e5813b98",
+        "dest-filename": "tesseract.js-dGVzc2VyYWN0LmpzQG5wbTo3LjAuMA==-eefcce0c14.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -35674,6 +35821,13 @@
         "url": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
         "sha512": "7001963c8c8e1d4eb396683cf23c26ed54725e730dee257af0e1806d80e4fcc87fc42fe9cd53e542d63a9e0a081ffe7fb5c8ae8467ef11253c1ab1eb7310f9eb",
         "dest-filename": "test-exclude-dGVzdC1leGNsdWRlQG5wbTo2LjAuMA==-8fccb2cb6c.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+        "sha512": "be52f2b5791e3f8c6f12ada8b477897d24084725b1a3fa191846d7aed10417d1e79ab765cb9f6c51bcd9fd08325ae2d81dcb421f1145e2d45064d43d93ad04c5",
+        "dest-filename": "text-decoder-dGV4dC1kZWNvZGVyQG5wbToxLjIuNw==-151f89339a.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -35811,6 +35965,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/tiny-async-pool/-/tiny-async-pool-1.3.0.tgz",
+        "sha512": "d35100c39103adc56b760c822e0a123efab39c2d2c5710d255e88ecf4f455298e1ef51bbf550aa9de3abfb1beded3d6befa085e9965f3e31e8acddbe77ede6a8",
+        "dest-filename": "tiny-async-pool-dGlueS1hc3luYy1wb29sQG5wbToxLjMuMA==-d516305223.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
         "sha512": "341e8393503dc6040f3281aa0b90955e7d76de05b2b5edb5e4e353e4fa796b4cade27944a0ed5959e0b0a6771a7a43c75ceeb48b8ee28459d93e244f8d132ae1",
         "dest-filename": "tiny-emitter-dGlueS1lbWl0dGVyQG5wbToyLjEuMA==-75633f4de4.tgz",
@@ -35846,6 +36007,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+        "sha512": "4877ffaf8f1beef3ab8ef7bd3f1268dcc379bf9caeca31ef75472b41f7d3dd65cc51f9c69870d56c2e24dec1c96894e0642c29529948680a3900db4cca9dd81e",
+        "dest-filename": "tinyexec-dGlueWV4ZWNAbnBtOjEuMi40-f20b3e6f56.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
         "sha512": "b57e5eece3351e762bdbe6b60bfe15d21b4e71241ca124c7f4a8099d5bcd9b9ce6fdcc8458a27b8fb62eb6c1fd0b131db4e9242c5cb6007acc722f4833c20f65",
         "dest-filename": "tinyglobby-dGlueWdsb2JieUBucG06MC4yLjE0-3d306d3197.tgz",
@@ -35856,6 +36024,13 @@
         "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
         "sha512": "8f666ae0dc90606e573124f871bb34d8093c88951dc513345c8e50cb15ee64ecca3883665aeae9dec997bb7cb9c03709ae9b70a528e05c7cc8431474a265e58d",
         "dest-filename": "tinyglobby-dGlueWdsb2JieUBucG06MC4yLjE1-d72bd826a8.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+        "sha512": "a67f7d561a0009847c9c51e1c6a8b1faebec6d78a77806ac5a6e688d7a0df311302b929ddff4eb84d9f5c01cae0f9d94c5644bcbca6efa444c9e2122e84abd66",
+        "dest-filename": "tinyglobby-dGlueWdsb2JieUBucG06MC4yLjE2-5c2c41b572.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -36105,13 +36280,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-        "sha512": "6cb54c2cfb6cb6567888c407a451d347b1801a3da3c62f03834b3687631a7c0138b92585f7c142ff7328994e7589000c7fcfea0d46ca59fe46c6ebef55c5c487",
-        "dest-filename": "tr46-dHI0NkBucG06Ni4wLjA=-e6d402eb2b.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.1.tgz",
         "sha512": "58291c44154f4a51c7ab575cfe9c7d88e7ea925bf309b751c2f94d7f1199b2b1ea7fa699b6d7cfaddec3253b7aa11d7477051fa451507954e43db0486715ff60",
         "dest-filename": "tree-dump-dHJlZS1kdW1wQG5wbToxLjAuMQ==-b19d0ce73d.tgz",
@@ -36238,6 +36406,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+        "sha512": "389fe26f184f96aacc33452234727fd02290928285db8dff0049a996ddeaa518245bc546ec87ce4b8d61ed5f138c84ea741c87ceb8dc4bfdac8becb894887c34",
+        "dest-filename": "ts-api-utils-dHMtYXBpLXV0aWxzQG5wbToyLjUuMA==-d5f1936f56.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
         "sha512": "ab95bbb5533bd5edb18c76539607d30e83c5fd29aa286e6175dabd4b3478f421f685acaa44a26d4389ad4654b129a26547ffbdac433e9a70477fb236fc141ca5",
         "dest-filename": "ts-dedent-dHMtZGVkZW50QG5wbToyLjIuMA==-93ed8f7878.tgz",
@@ -36259,9 +36434,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.1.tgz",
-        "sha512": "49a794b637e983d52abbc21b7832ad75a4b483c952e854fa3b33377b3ac37c4acf24f1cd0e8fc4cbe54518fd5b4080df6a06032f246977b3b5e57a46d44b3653",
-        "dest-filename": "ts-jest-dHMtamVzdEBucG06MjkuNC4x-6aed48232c.tgz",
+        "url": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.6.tgz",
+        "sha512": "7d2a56b4e3bfd408d235082e938de16ff242a35ea82439cc25fdc274418d92ab045f7b74297f7ac6fc97d43ecf7cb0a95682aee0c7d5aea5241726e562863894",
+        "dest-filename": "ts-jest-dHMtamVzdEBucG06MjkuNC42-e0ff9e13f6.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -36357,13 +36532,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-        "sha512": "98728ade25172fedd417ac4be64d0f12129150128f042bfff919043a98d15b1c71dbb28a4419a603ad00f6980e52f322f062a144c3c49a30513f3b365bb3b538",
-        "dest-filename": "tsutils-dHN1dGlsc0BucG06My4yMS4w-ea036bec1d.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
         "sha512": "6b1af721d36e548c6768ae571845054eedd898043a965960aefa9f128475ea0fc71a7618ffa59ee2858436d027ccaebf2e9276babf4f01bf34441b7bfd4e2e83",
         "dest-filename": "tsyringe-dHN5cmluZ2VAbnBtOjQuMTAuMA==-b42660dc11.tgz",
@@ -36399,9 +36567,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/turndown/-/turndown-7.2.2.tgz",
-        "sha512": "d45edd6fc06213138ac6348c5366fb89feb60ff5cec90c996cf2aafe7530a297e09c796a5c7a90d25bdf51379422bd65649cce3c59f8ddd383c8c4887ef59129",
-        "dest-filename": "turndown-dHVybmRvd25AbnBtOjcuMi4y-e0a6f7f0c2.tgz",
+        "url": "https://registry.npmjs.org/turndown/-/turndown-7.2.4.tgz",
+        "sha512": "23cc85b1f4739b32b4595d6934d380e00ef2e110df1713d1c5bdedf9edee8b5e2a4863b11ad8923fa1a3797f98e821dbec761a163ec40940fb544e6440c65619",
+        "dest-filename": "turndown-dHVybmRvd25AbnBtOjcuMi40-90e3e0370a.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -36528,6 +36696,13 @@
         "url": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
         "sha512": "4de4d243a1f9607be9a95c0145c9cb0c20670ce1d662eec8bc66c74fa37c00eca672bf4f2468dcd464ed896653620d0d0a0630be761612454285002bf5b8dfc0",
         "dest-filename": "type-fest-dHlwZS1mZXN0QG5wbTo0LjQxLjA=-617ace794a.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+        "sha512": "f19887166f75a2b6d201ed8f480892541564a35f296e16e207753d1a0952cc5ff3086911fabc691f1eac10c0949b89316382e30c85068027d432dc1f65f8df50",
+        "dest-filename": "type-fest-dHlwZS1mZXN0QG5wbTo1LjYuMA==-2cc7a510f4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -36668,13 +36843,6 @@
         "url": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
         "sha512": "0b45904f481ecc7bb0e80758d4cda3c543bcdd18dfd073fb4a4d43b578fa8f5130910359ac7020d973d696aeb6a2a12162f38dab9a640b663da0f963593a0b99",
         "dest-filename": "typescript-dHlwZXNjcmlwdEBucG06NC43LjQ=-f056b2313a.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-        "sha512": "d455e4f44d879be433650ef3f8c7098872f8356d45d84cccbbd36af62df301a1aa89b69fa98c02554e96c9602ec90451cce971a2ef31652c972c437ca0a8f6e2",
-        "dest-filename": "typescript-dHlwZXNjcmlwdEBucG06NC45LjU=-458f7220ab.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -36847,9 +37015,30 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+        "sha512": "591356fac2608f9381378ff42691c5aadab38696e75741ae07e3a8cc0f6008bedaf7ddd2994fb5241642ccb37162c6cc7c87832fe953b29843e6337937e9f4ce",
+        "dest-filename": "undici-types-dW5kaWNpLXR5cGVzQG5wbTo3LjI0LjY=-defc9538b9.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/undici/-/undici-6.21.2.tgz",
         "sha512": "b913995b37b44748ad8802953ec621168bfd2f1acf3072cc11016ccde23680237a6e720867cb70cc108970dd8b26b0412dfacfd2dd455b483e26629597c564d6",
         "dest-filename": "undici-dW5kaWNpQG5wbTo2LjIxLjI=-9cd9ead225.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+        "sha512": "6267d5dd89c40f35d10b9959da35ad5961ca1949b5cc8b7c0217ac475b5e9ecf874cdbfe61994dfdda7a1bbdbb2cebcc27cc633fd05eed8d9276bf7a2c39bea6",
+        "dest-filename": "undici-dW5kaWNpQG5wbTo2LjI3LjA=-30c18cdb23.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/undici/-/undici-7.26.0.tgz",
+        "sha512": "dcef537faee91a180ebfd8ccdf901b8645c02a2d777f7a32dda13809282bf9372419e63efe2bbded95cdf89ec3a473f32db540a4577520585c9c18d11185d872",
+        "dest-filename": "undici-dW5kaWNpQG5wbTo3LjI2LjA=-c55b8f8e37.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -36966,13 +37155,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
-        "sha512": "383587b6491dc7720047ebde2b1155f9506450c70df856aacd451dec8673b7ed338436453c5c6196ac0f177610bcc1f1d530f4b5d81897e92e3e727c13aaa5ec",
-        "dest-filename": "unique-filename-dW5pcXVlLWZpbGVuYW1lQG5wbToyLjAuMQ==-807acf3381.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/unique-filename/-/unique-filename-3.0.0.tgz",
         "sha512": "69f5e1b82e79c240266743f5f10b1513a929f096b1ac4a243761c6228215bf68a31d0778d7d1f4fba12280015c2335de30891c224341a41dcbfc35c1ddc4d2fe",
         "dest-filename": "unique-filename-dW5pcXVlLWZpbGVuYW1lQG5wbTozLjAuMA==-8e2f59b356.tgz",
@@ -36990,13 +37172,6 @@
         "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
         "sha512": "ce85abf4e6dac402c3dc338f7e33d2ab1b787e766259b9711c881e5aa5bcc7b52a0f312d1c440bce38b672e258405094e8a9a826290e600665ad31c779b8f1db",
         "dest-filename": "unique-slug-dW5pcXVlLXNsdWdAbnBtOjIuMC4y-6cfaf91976.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
-        "sha512": "f04c8cca787aefdc7fd20a84f5f4fda22946faa12dfa26c5caa8ee553b199f5f823311fe5cb969bebd94671e2755c0b04e9c7cd67202af625016433e1cf2eae3",
-        "dest-filename": "unique-slug-dW5pcXVlLXNsdWdAbnBtOjMuMC4w-26fc5bc209.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -37211,6 +37386,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+        "sha512": "3d9f214d2f80a9c1b1b1a427b65dc8441c3ae50ac123a971cea0c42fb200a3f5c212a4532867ce5f9e9579ae531fd499733455c6ece4d6b7b4e33fd88ee60224",
+        "dest-filename": "unzipper-dW56aXBwZXJAbnBtOjAuMTIuMw==-b210c42130.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
         "sha512": "699c06a5a9853bad60dce95f4fb390087aa11a75b8de2787f5665e3fb43137f1bf8d2e237ea524671a2bcaf26054f11cae5e4d2ff8201ec4a62cc1ee1fae0b86",
         "dest-filename": "upath-dXBhdGhAbnBtOjEuMi4w-ac07351d9e.tgz",
@@ -37407,6 +37589,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+        "sha512": "3e9e864b018ffcdacf22bc551402243907b2c3c9457a73878a34169144eb0efac5e002eaca53f60bf28291e4bd76950cdcabd84508676b9bedec82fde7e650f7",
+        "dest-filename": "use-sync-external-store-dXNlLXN5bmMtZXh0ZXJuYWwtc3RvcmVAbnBtOjEuNi4w-b40ad2847b.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
         "sha512": "73011255794edeeae5f585a5156fd303d72c842121b6eec8289fe9e6ca09fe01a98fbbdbbc5ac063f7888a843a0f0db72a3661620888a3c1ceb359d0dafaffa1",
         "dest-filename": "use-dXNlQG5wbTozLjEuMQ==-08a130289f.tgz",
@@ -37498,6 +37687,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+        "sha512": "bc8631ac1082fcdfcaf89b37a9237cf20a3b9087cd3ecb2bfe11c27ac28240d0239a0bd84b6a2aafaf6422e7c41be3b8f8f7decce1f811b21e1c27c5a2ff1981",
+        "dest-filename": "uuid-dXVpZEBucG06MTEuMS4x-16411d3dc1.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
         "sha512": "5d07a021a0535548d21e588aa9c9c5a98ca901de12f96098b79348791b3ac3f500af2ef3f18f63e59c1144be24ceaf54dec0fabfef397abf45be411a0698e2db",
         "dest-filename": "uuid-dXVpZEBucG06MTMuMC4w-2742b24d1e.tgz",
@@ -37536,13 +37732,6 @@
         "url": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
         "sha512": "3177124deadf3dae2eab2cd2b5b4684e0b795c87b7c79fb8dbeab5b03bb2dd1e4c0e4eba51174b30e65ee5a3d7fd241dfa4b98021d0574ffe93b6f08910c937a",
         "dest-filename": "uuid-dXVpZEBucG06OS4wLjA=-23857699a6.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-        "sha512": "6fed5e24e96c47d2bc1c9a68c3d3a4ddf896396488708cd7a1dbefd2b42356839536958ca717f5c19369b78cbd875d2874236baa7629d4e073464b5c9017b7b0",
-        "dest-filename": "uuid-dXVpZEBucG06OS4wLjE=-9d0b6adb72.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -37620,13 +37809,6 @@
         "url": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
         "sha512": "65929298300414e8a311104b92661f27ebe6937c3eee138b603364442b91b8c246126a9834234bc81045c162953217f068417758e774665c3ce94fd60bffa763",
         "dest-filename": "verror-dmVycm9yQG5wbToxLjEwLjA=-da548149dd.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-        "sha512": "bdeb9f726c6b8b87b75d2ad3d31c1f511ee482e2246b105ea2c0e0d34c835a1938f7077091252bbefb26ee773be5ed4f532bc87998fa9d2f15411633dbf4b85e",
-        "dest-filename": "verror-dmVycm9yQG5wbToxLjEwLjE=-2b24eb830e.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -37834,16 +38016,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/warn-once/-/warn-once-0.1.1.tgz",
-        "sha512": "56441925b3bccd5226cd816d7815ef04e644975a8bd7be561fc56665cc45d9f640a2e74d84d0ef1e2f9da0268011d536976bed708c1adb39f440ae7e2351d0dd",
-        "dest-filename": "warn-once-d2Fybi1vbmNlQG5wbTowLjEuMQ==-e6a5a1f5a8.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.5.1.tgz",
-        "sha512": "187af6dea9ae7a13571d8e3dd36fe127a115e6c500348242dd1ff231f43b8560e0de77e195c25f9c82fde91da88692306bad9aada37a68de1b2f3cf3ab919792",
-        "dest-filename": "wasm-feature-detect-d2FzbS1mZWF0dXJlLWRldGVjdEBucG06MS41LjE=-e5a63a0a4a.tgz",
+        "url": "https://registry.npmjs.org/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
+        "sha512": "ce4b1a2ca3367d59670798d0403a8a5d7c181cb414547f5eb3ee5338e1f018e54938279104288f8f04a0fb7b4dd807530b38e0962e238a3087dbdd245dbff359",
+        "dest-filename": "wasm-feature-detect-d2FzbS1mZWF0dXJlLWRldGVjdEBucG06MS44LjA=-54662197b4.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -37911,6 +38086,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+        "sha512": "82c5de726f365103654c1511246baa396cb55b0d3c4b791951caf768e252d363e4d312ed91f7940150b4bb4c6181da271667bcd1e752254209caebcbffbdb9d1",
+        "dest-filename": "webcrypto-core-d2ViY3J5cHRvLWNvcmVAbnBtOjEuOS4y-bb9a21bbd7.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
         "sha512": "d89027df3f0047aae32bc4a6f28ad10b487f6dc97f0ea2fbb513dd199e08d428dd17e11a30b998c411f25ee28bf38f5eb9c3c586f068c4cb1f95f39bf24c5a79",
         "dest-filename": "webidl-conversions-d2ViaWRsLWNvbnZlcnNpb25zQG5wbTozLjAuMQ==-b65b9f8d68.tgz",
@@ -37942,13 +38124,6 @@
         "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
         "sha512": "57075d06e903ceeef5a1f7c0411f7be6e9c1206a9f299a4cfbc657eb24a4f27621568a39098699cb3b77601bd8b51b4ef9aa0696ac4f83f07cecd19567f7eeea",
         "dest-filename": "webidl-conversions-d2ViaWRsLWNvbnZlcnNpb25zQG5wbTo3LjAuMA==-4c4f65472c.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-        "sha512": "04c84b0ff4b0f866c90b6d42fd48326995f8d673edf1b51383e8d6c837a0edeed8378c4e334e583d221771e0029d756dab2130fcb30295440cb4c67e3c61a9a9",
-        "dest-filename": "webidl-conversions-d2ViaWRsLWNvbnZlcnNpb25zQG5wbTo4LjAuMQ==-0f7007311f.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -38005,6 +38180,13 @@
         "url": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
         "sha512": "f46caed85efe6e0e15bfea636e8bee6038475fe9aa76a213ca47f374cf54c8aa8a1e5b04e5a02346147ea0e11f5d6e6f05ebbcb5aaf394914866f6b866301dad",
         "dest-filename": "webpack-dev-server-d2VicGFjay1kZXYtc2VydmVyQG5wbTo1LjIuMw==-6a3d55c5d8.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+        "sha512": "1aa0cf19937d6d1a8a053929e1a5a4a1b0c31ccb2b5caa0649d387e7ab2622b8bca91d091bc81f2fcfeffdffce651dff38a5e31bcbb025b15584a9bf14d53f50",
+        "dest-filename": "webpack-dev-server-d2VicGFjay1kZXYtc2VydmVyQG5wbTo1LjIuNA==-5e5382f8cc.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -38086,9 +38268,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/webpackbar/-/webpackbar-6.0.1.tgz",
-        "sha512": "4e712b6699ae29dc1605d3287b18e2a3728a5fa66da0a1d156f2c8534038ed1d155410edc776723890e4b60622c61a09a24653613b75677ece90ef699c625af5",
-        "dest-filename": "webpackbar-d2VicGFja2JhckBucG06Ni4wLjE=-9da47f8dcb.tgz",
+        "url": "https://registry.npmjs.org/webpackbar/-/webpackbar-7.0.0.tgz",
+        "sha512": "692f6ca2a48eda208782a1e80ab8f82db7c64146e80c26093d214e01c8442bef69b088cdadf4965b8634604cfaecc29444dbcc99fa34c9c3a0f5dffe38e7fdfd",
+        "dest-filename": "webpackbar-d2VicGFja2JhckBucG06Ny4wLjA=-d123164e26.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -38180,13 +38362,6 @@
         "url": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
         "sha512": "0deef619d419ccd4d40410a1b17b9e4149cf283920ff9039ce9ee9143b90023e5416810da62002534c250afce90069d3923fbe8a1a4ac0ac987b09ff5cd51b2b",
         "dest-filename": "whatwg-url-d2hhdHdnLXVybEBucG06MTQuMi4w-f0a95b0601.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-        "sha512": "db2b43934922123ff2bbdd09380a78e0f54f5243bdfa3561c9ff92c9b2a544748396f38e66174f22bafbc531fae25e168b13b670ffb0408720ba390604f3f3ea",
-        "dest-filename": "whatwg-url-d2hhdHdnLXVybEBucG06MTUuMS4w-9ae5ce7006.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -38306,6 +38481,13 @@
         "url": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
         "sha512": "244746cc7c3092b6d6a063a5207a90e60b69aca18e7a7a431e9c44f73551d5b59b3ad611c8f3c731ef4568feb1eb50a635a4d385291bd03009b5ee630fe0e6cd",
         "dest-filename": "which-d2hpY2hAbnBtOjUuMC4w-6ec99e89ba.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+        "sha512": "a062dee3a308ac246a5fbcad3d47fae84018bdd78c219627dd66a872aa8a640c6b06992a1df2ffaaf4f227f6d3939f80a870a35e6aefdc2116832dfaf3385152",
+        "dest-filename": "which-d2hpY2hAbnBtOjYuMC4x-dbea77c7d3.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -38541,6 +38723,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/wunderbaum/-/wunderbaum-0.14.1.tgz",
+        "sha512": "442a50c5f9892ecf3bc6a1f1a88ea05d6de185108c11039e5245655f2901b4a36e5cb506eb28d4df5b6613bb94cb6ed1ed67321ecfd9883aae65392ab2d10874",
+        "dest-filename": "wunderbaum-d3VuZGVyYmF1bUBucG06MC4xNC4x-b0a652e105.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
         "sha512": "902cf993b27b5db26d8c004ebe47399499a488387c5618d5086362a9d282b1c995a5d554a440325efd719822e4409e5db07ab1dc83cee175be3530e153f7dab4",
         "dest-filename": "xcode-eGNvZGVAbnBtOjMuMC4x-539d7b808c.tgz",
@@ -38681,6 +38870,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+        "sha512": "17117afab92bd6b35242b854358ac0149a515cdce50e8331797379a88f38f77f72944bf7aaa3c529af393b1afab436892aac16e8a2b2a36bf6e934afde4e8b78",
+        "dest-filename": "xpath-eHBhdGhAbnBtOjAuMC4zNA==-77ce03c449.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
         "sha512": "2ca614d620172575200179fd5118e2bbe3168725171ecbdfa7b99cb989bd75250a2b4fc28edad4c050310fcdbf98259bb4bb068c521a774c08b28778ceb4c011",
         "dest-filename": "xtend-eHRlbmRAbnBtOjQuMC4y-ac5dfa738b.tgz",
@@ -38747,6 +38943,13 @@
         "url": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
         "sha512": "9a99729caa9cd42da14d56317743d4db1400736d93235bd284060692c0827f16e7fdd1709c74cd8b56ef62c05392175436d1887f9c4d3a0f77f2bad2498bd2f4",
         "dest-filename": "yaml-eWFtbEBucG06Mi44LjI=-4eab0074da.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+        "sha512": "d80be1357de66fccdde99cbb20d4ed4a9975175e475ba5a7aa3d2cad696428b729625fe03083098b2b86ab629e236605c543e376507edcb735d2c78c2ed2f870",
+        "dest-filename": "yaml-eWFtbEBucG06Mi45LjA=-9a95e8e086.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -38828,13 +39031,6 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-        "sha512": "d7ff54add1e30d973478e5341f1387a12efc0baf540f725132fce527b4bbf52da74da59103fc211824d5f28f5efcdff555af58215ed0e2c3b10fc555e290963b",
-        "dest-filename": "yargs-eWFyZ3NAbnBtOjE3LjYuMg==-77e4221b49.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
         "url": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
         "sha512": "edd4b3cd143ef822a7348fe4aca9d8455ec928a3d45cc121eb5b286872a0f66ad6121cc55a1167c4fc4697eebd703d4ebbadc2d773543c29e621caefa82b8ceb",
         "dest-filename": "yargs-eWFyZ3NAbnBtOjE3LjcuMg==-abb3e37678.tgz",
@@ -38856,16 +39052,9 @@
     },
     {
         "type": "file",
-        "url": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-        "sha512": "a786bd23a5fa9eee888681a606a01c6c9cb59a50b88f6eef10f657f45e0be3fbd94f72f2ab5564147c3f57f3d4701f41ba8f831b7887913d31dd0c9ae7ccdcde",
-        "dest-filename": "yauzl-eWF1emxAbnBtOjIuMTAuMA==-1e4c311050.tgz",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
-    },
-    {
-        "type": "file",
-        "url": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-        "sha512": "3b0f67b86644faaa75bb82483ef83eb82894afbc4641675f7fb2504a4e551984c064c0dedaaf25c49d74ca0bf5d2a9928f4df54f2ffa14d2692cee28d5281cfb",
-        "dest-filename": "yauzl-eWF1emxAbnBtOjMuMi4w-a3cd2bfcf7.tgz",
+        "url": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.1.tgz",
+        "sha512": "44d3c2524884fd980ee30f22f54e720d05476850dd9f368500d12546fa49b5e0aca6f9afd95aab45bf65bd2ea87550fe8ea23fcc3b31007255b1a7e972179541",
+        "dest-filename": "yauzl-eWF1emxAbnBtOjMuMy4x-b9ecac2dca.tgz",
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
@@ -38940,6 +39129,13 @@
     },
     {
         "type": "file",
+        "url": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+        "sha512": "087394cbb9aede56c3ea8e8b24b7e59698e4ce11d7481957f01f7ea8f75d52c21f785e52fd4679ab49260ac9d1a93d541c54197213450c3ccc6d0b2e7ac1d697",
+        "dest-filename": "zustand-enVzdGFuZEBucG06NC41Ljc=-21c47ea1c9.tgz",
+        "dest": "flatpak-node/yarn-berry/cache/locator"
+    },
+    {
+        "type": "file",
         "url": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
         "sha512": "579d0a330c33a89574369648645c1f383e7f9729f2dd6952cd1897800d06ed5527465aadb6d6b52fa510207cdde84b8163f70719fc1321c93bc35c87e90e7353",
         "dest-filename": "zwitch-endpdGNoQG5wbToxLjAuNQ==-28a1bebaca.tgz",
@@ -38960,52 +39156,10 @@
         "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
-        "type": "git",
-        "url": "https://github.com/electron/node-gyp.git",
-        "commit": "06b29aafb7708acef8b3669835c8a7857ebc92d2",
-        "dest": "flatpak-node/tmp/node-gyp"
-    },
-    {
         "type": "inline",
         "contents": "const PackageManager = {\n  Yarn1: `Yarn Classic`,\n  Yarn2: `Yarn`,\n  Npm: `npm`,\n  Pnpm: `pnpm`,\n}\n\nmodule.exports = {\n  name: `flatpak-builder`,\n  factory: require => {\n    const { BaseCommand } = require(`@yarnpkg/cli`);\n    const { parseSyml } = require('@yarnpkg/parsers');\n    const { Configuration, Manifest, scriptUtils, structUtils, tgzUtils, execUtils, miscUtils, hashUtils } = require('@yarnpkg/core')\n    const { Filename, ZipFS, npath, ppath, PortablePath, xfs } = require('@yarnpkg/fslib');\n    const { getLibzipPromise } = require('@yarnpkg/libzip');\n    const { gitUtils } = require('@yarnpkg/plugin-git');\n    const { PassThrough, Readable, Writable } = require('stream');\n    const { Command, Option } = require(`clipanion`);\n    const { YarnVersion } = require('@yarnpkg/core');\n    const fs = require('fs');\n\n    // from https://github.com/yarnpkg/berry/blob/%40yarnpkg/shell/3.2.3/packages/plugin-essentials/sources/commands/set/version.ts#L194 \n    async function setPackageManager(projectCwd) {\n      const bundleVersion = YarnVersion;\n\n      const manifest = (await Manifest.tryFind(projectCwd)) || new Manifest();\n\n      if (bundleVersion && miscUtils.isTaggedYarnVersion(bundleVersion)) {\n        manifest.packageManager = `yarn@${bundleVersion}`;\n        const data = {};\n        manifest.exportTo(data);\n\n        const path = ppath.join(projectCwd, Manifest.fileName);\n        const content = `${JSON.stringify(data, null, manifest.indent)}\\n`;\n\n        await xfs.changeFilePromise(path, content, {\n          automaticNewlines: true,\n        });\n      }\n    }\n\n    // func from https://github.com/yarnpkg/berry/blob/%40yarnpkg/shell/3.2.3/packages/yarnpkg-core/sources/scriptUtils.ts#L215\n    async function prepareExternalProject(cwd, outputPath, { configuration, locator, stdout, yarn_v1, workspace = null }) {\n      const devirtualizedLocator = locator && structUtils.isVirtualLocator(locator)\n        ? structUtils.devirtualizeLocator(locator)\n        : locator;\n\n      const name = devirtualizedLocator\n        ? structUtils.stringifyLocator(devirtualizedLocator)\n        : `an external project`;\n\n      const stderr = stdout;\n\n      stdout.write(`Packing ${name} from sources\\n`);\n\n      const packageManagerSelection = await scriptUtils.detectPackageManager(cwd);\n      let effectivePackageManager;\n      if (packageManagerSelection !== null) {\n        stdout.write(`Using ${packageManagerSelection.packageManager} for bootstrap. Reason: ${packageManagerSelection.reason}\\n\\n`);\n        effectivePackageManager = packageManagerSelection.packageManager;\n      } else {\n        stdout.write(`No package manager configuration detected; defaulting to Yarn\\n\\n`);\n        effectivePackageManager = PackageManager.Yarn2;\n      }\n      if (effectivePackageManager === PackageManager.Pnpm) {\n        effectivePackageManager = PackageManager.Npm;\n      }\n\n      const workflows = new Map([\n        [PackageManager.Yarn1, async () => {\n          const workspaceCli = workspace !== null\n            ? [`workspace`, workspace]\n            : [];\n\n          await setPackageManager(cwd);\n\n          await Configuration.updateConfiguration(cwd, {\n            yarnPath: yarn_v1,\n          });\n\n          await xfs.appendFilePromise(ppath.join(cwd, `.npmignore`), `/.yarn\\n`);\n\n          const pack = await execUtils.pipevp(`yarn`, [...workspaceCli, `pack`, `--filename`, npath.fromPortablePath(outputPath)], { cwd, stdout, stderr });\n          if (pack.code !== 0)\n            return pack.code;\n\n          return 0;\n        }],\n        [PackageManager.Yarn2, async () => {\n          const workspaceCli = workspace !== null\n            ? [`workspace`, workspace]\n            : [];\n          const lockfilePath = ppath.join(cwd, Filename.lockfile);\n          if (!(await xfs.existsPromise(lockfilePath)))\n            await xfs.writeFilePromise(lockfilePath, ``);\n\n          const pack = await execUtils.pipevp(`yarn`, [...workspaceCli, `pack`, `--filename`, npath.fromPortablePath(outputPath)], { cwd, stdout, stderr });\n          if (pack.code !== 0)\n            return pack.code;\n          return 0;\n        }],\n        [PackageManager.Npm, async () => {\n          const workspaceCli = workspace !== null\n            ? [`--workspace`, workspace]\n            : [];\n          const packStream = new PassThrough();\n          const packPromise = miscUtils.bufferStream(packStream);\n          const pack = await execUtils.pipevp(`npm`, [`pack`, `--silent`, ...workspaceCli], { cwd, stdout: packStream, stderr });\n          if (pack.code !== 0)\n            return pack.code;\n\n          const packOutput = (await packPromise).toString().trim().replace(/^.*\\n/s, ``);\n          const packTarget = ppath.resolve(cwd, npath.toPortablePath(packOutput));\n          await xfs.renamePromise(packTarget, outputPath);\n          return 0;\n        }],\n      ]);\n      const workflow = workflows.get(effectivePackageManager);\n      const code = await workflow();\n      if (code === 0 || typeof code === `undefined`)\n        return;\n      else\n        throw `Packing the package failed (exit code ${code})`;\n    }\n\n    class convertToZipCommand extends BaseCommand {\n      static paths = [[`convertToZip`]];\n      yarn_v1 = Option.String({ required: true });\n\n      async execute() {\n        const configuration = await Configuration.find(this.context.cwd,\n          this.context.plugins);\n        const lockfilePath = ppath.join(this.context.cwd, 'yarn.lock');\n        const cacheFolder = `${configuration.get('globalFolder')}/cache`;\n        const locatorFolder = `${cacheFolder}/locator`;\n\n        const compressionLevel = configuration.get(`compressionLevel`);\n        const stdout = this.context.stdout;\n        const gitChecksumPatches = []; // {name:, oriHash:, newHash:}\n\n        async function patchLockfileChecksum(lockfilePath, patches) {\n          let currentContent = ``;\n          try {\n            currentContent = await xfs.readFilePromise(lockfilePath, `utf8`);\n          } catch (error) {\n          }\n          const newContent = patches.reduce((acc, item, i) => {\n            stdout.write(`patch '${item.name}' checksum:\\n-${item.oriHash}\\n+${item.newHash}\\n\\n\\n`);\n            const regex = new RegExp(item.oriHash, \"g\");\n            return acc.replace(regex, item.newHash);\n          }, currentContent);\n\n          await xfs.writeFilePromise(lockfilePath, newContent);\n        }\n\n        async function getLockFileMeta(lockfilePath) {\n          const content = await xfs.readFilePromise(lockfilePath, `utf8`);\n          const parsed = parseSyml(content);\n          return parsed.__metadata;\n        }\n\n        const lockMeta = await getLockFileMeta(lockfilePath);\n        stdout.write(`yarn lock:          ${lockfilePath}\\n`);\n        stdout.write(`yarn lock version:  ${lockMeta.version}\\n`);\n        stdout.write(`yarn lock cacheKey: ${lockMeta.cacheKey}\\n`);\n\n        const convertToZip = async (tgz, target, opts) => {\n          const tgzBuf = await xfs.readFilePromise(tgz);\n          const fs = await tgzUtils.convertToZip(tgzBuf, opts);\n          fs.discardAndClose();\n          await xfs.copyFilePromise(fs.path, target);\n          await xfs.unlinkPromise(fs.path);\n        }\n\n        stdout.write(`converting tgz to zip: ${cacheFolder}\\n`);\n\n        const files = fs.readdirSync(locatorFolder);\n        const tasks = []\n        for (const i in files) {\n          const file = `${files[i]}`;\n          let tgzFile = `${locatorFolder}/${file}`;\n          const match = file.match(/([^-]+)-([^.]{1,10})[.](tgz|git)$/);\n          if (!match) {\n            stdout.write(`ignore ${file}\\n`);\n            continue;\n          }\n          let resolution, locator;\n          const entry_type = match[3];\n          const sha = match[2];\n          let checksum;\n\n          if (entry_type === 'tgz') {\n            resolution = Buffer.from(match[1], 'base64').toString();\n            locator = structUtils.parseLocator(resolution, true);\n          }\n          else if (entry_type === 'git') {\n            const gitJson = JSON.parse(fs.readFileSync(tgzFile, 'utf8'));\n\n            resolution = gitJson.resolution;\n            locator = structUtils.parseLocator(resolution, true);\n            checksum = gitJson.checksum;\n\n            const repoPathRel = gitJson.repo_dir_rel;\n\n            const cloneTarget = `${cacheFolder}/${repoPathRel}`;\n\n            const repoUrlParts = gitUtils.splitRepoUrl(locator.reference);\n            const packagePath = ppath.join(cloneTarget, `package.tgz`);\n\n            await prepareExternalProject(cloneTarget, packagePath, {\n              configuration: configuration,\n              stdout,\n              workspace: repoUrlParts.extra.workspace,\n              locator,\n              yarn_v1: this.yarn_v1,\n            });\n\n            tgzFile = packagePath;\n\n          }\n          const filename =\n            `${structUtils.slugifyLocator(locator)}-${lockMeta.cacheKey}.zip`;\n          const targetFile = `${cacheFolder}/${filename}`\n\n          tasks.push(async () => {\n            await convertToZip(tgzFile, targetFile, {\n              compressionLevel: compressionLevel,\n              prefixPath: `node_modules/${structUtils.stringifyIdent(locator)}`,\n              stripComponents: 1,\n            });\n\n            if (entry_type === 'git') {\n              const file_checksum = await hashUtils.checksumFile(targetFile);\n\n              if (file_checksum !== checksum) {\n                const newSha = file_checksum.slice(0, 10);\n                const newTarget = `${cacheFolder}/${structUtils.slugifyLocator(locator)}-${lockMeta.cacheKey}.zip`;\n                fs.renameSync(targetFile, newTarget);\n\n                gitChecksumPatches.push({\n                  name: locator.name,\n                  oriHash: checksum,\n                  newHash: file_checksum,\n                });\n              }\n            }\n          });\n        }\n\n        await Promise.all(tasks.map(t => t()));\n\n        patchLockfileChecksum(lockfilePath, gitChecksumPatches);\n        stdout.write(`converting finished\\n`);\n      }\n    }\n    return {\n      commands: [\n        convertToZipCommand\n      ],\n    };\n  }\n};\n",
         "dest-filename": "flatpak-yarn.js",
         "dest": "flatpak-node"
-    },
-    {
-        "type": "inline",
-        "contents": "flatpak-node-cache",
-        "dest-filename": "INSTALLATION_COMPLETE",
-        "dest": "flatpak-node/cache/ms-playwright/chromium-1200"
-    },
-    {
-        "type": "inline",
-        "contents": "flatpak-node-cache",
-        "dest-filename": "INSTALLATION_COMPLETE",
-        "dest": "flatpak-node/cache/ms-playwright/chromium-headless-shell-1200"
-    },
-    {
-        "type": "inline",
-        "contents": "flatpak-node-cache",
-        "dest-filename": "INSTALLATION_COMPLETE",
-        "dest": "flatpak-node/cache/ms-playwright/ffmpeg-1011"
-    },
-    {
-        "type": "inline",
-        "contents": "flatpak-node-cache",
-        "dest-filename": "INSTALLATION_COMPLETE",
-        "dest": "flatpak-node/cache/ms-playwright/firefox-1497"
-    },
-    {
-        "type": "inline",
-        "contents": "flatpak-node-cache",
-        "dest-filename": "INSTALLATION_COMPLETE",
-        "dest": "flatpak-node/cache/ms-playwright/webkit-2227"
-    },
-    {
-        "type": "inline",
-        "contents": "{\"repo_dir_rel\": \"../../tmp/node-gyp\", \"resolution\": \"@electron/node-gyp@https://github.com/electron/node-gyp.git#commit=06b29aafb7708acef8b3669835c8a7857ebc92d2\", \"checksum\": \"4ee7c77e1a9f581e36b53f393984e40284dcf9ed38ea51265bb5a4fcc51ea7e86e7765a8b8cfac6405506de04f2464c7379ce3f14485ead36dec13eba78c089c\"}",
-        "dest-filename": "node-gyp-Z2l0-4ee7c77e1a.git",
-        "dest": "flatpak-node/yarn-berry/cache/locator"
     },
     {
         "type": "script",
@@ -39049,9 +39203,50 @@
     {
         "type": "shell",
         "commands": [
+            "mkdir -p \"bc80a13ebe4734629db853b3fc870b18ba9e388b795710fdbbd075694e548d03\"",
+            "ln -s \"../SHASUMS256.txt-42.3.0\" \"bc80a13ebe4734629db853b3fc870b18ba9e388b795710fdbbd075694e548d03/SHASUMS256.txt\""
+        ],
+        "dest": "flatpak-node/cache/electron"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bc80a13ebe4734629db853b3fc870b18ba9e388b795710fdbbd075694e548d03\"",
+            "ln -s \"../electron-v42.3.0-linux-arm64.zip\" \"bc80a13ebe4734629db853b3fc870b18ba9e388b795710fdbbd075694e548d03/electron-v42.3.0-linux-arm64.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bc80a13ebe4734629db853b3fc870b18ba9e388b795710fdbbd075694e548d03\"",
+            "ln -s \"../electron-v42.3.0-linux-armv7l.zip\" \"bc80a13ebe4734629db853b3fc870b18ba9e388b795710fdbbd075694e548d03/electron-v42.3.0-linux-armv7l.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bc80a13ebe4734629db853b3fc870b18ba9e388b795710fdbbd075694e548d03\"",
+            "ln -s \"../electron-v42.3.0-linux-x64.zip\" \"bc80a13ebe4734629db853b3fc870b18ba9e388b795710fdbbd075694e548d03/electron-v42.3.0-linux-x64.zip\""
+        ],
+        "dest": "flatpak-node/cache/electron",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
             "mkdir -p \"bin/@esbuild\"",
-            "cp \".package/@esbuild/linux-arm64@0.27.2/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.27.2\"",
-            "ln -sf \"linux-arm64@0.27.2\" \"bin/esbuild-current\""
+            "cp \".package/@esbuild/linux-arm64@0.27.5/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.27.5\"",
+            "ln -sf \"linux-arm64@0.27.5\" \"bin/esbuild-current\""
         ],
         "dest": "flatpak-node/cache/esbuild",
         "only-arches": [
@@ -39074,8 +39269,8 @@
         "type": "shell",
         "commands": [
             "mkdir -p \"bin/@esbuild\"",
-            "cp \".package/@esbuild/linux-arm@0.27.2/bin/esbuild\" \"bin/@esbuild/linux-arm@0.27.2\"",
-            "ln -sf \"linux-arm@0.27.2\" \"bin/esbuild-current\""
+            "cp \".package/@esbuild/linux-arm@0.27.5/bin/esbuild\" \"bin/@esbuild/linux-arm@0.27.5\"",
+            "ln -sf \"linux-arm@0.27.5\" \"bin/esbuild-current\""
         ],
         "dest": "flatpak-node/cache/esbuild",
         "only-arches": [
@@ -39098,8 +39293,8 @@
         "type": "shell",
         "commands": [
             "mkdir -p \"bin/@esbuild\"",
-            "cp \".package/@esbuild/linux-ia32@0.27.2/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.27.2\"",
-            "ln -sf \"linux-ia32@0.27.2\" \"bin/esbuild-current\""
+            "cp \".package/@esbuild/linux-ia32@0.27.5/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.27.5\"",
+            "ln -sf \"linux-ia32@0.27.5\" \"bin/esbuild-current\""
         ],
         "dest": "flatpak-node/cache/esbuild",
         "only-arches": [
@@ -39122,8 +39317,8 @@
         "type": "shell",
         "commands": [
             "mkdir -p \"bin/@esbuild\"",
-            "cp \".package/@esbuild/linux-x64@0.27.2/bin/esbuild\" \"bin/@esbuild/linux-x64@0.27.2\"",
-            "ln -sf \"linux-x64@0.27.2\" \"bin/esbuild-current\""
+            "cp \".package/@esbuild/linux-x64@0.27.5/bin/esbuild\" \"bin/@esbuild/linux-x64@0.27.5\"",
+            "ln -sf \"linux-x64@0.27.5\" \"bin/esbuild-current\""
         ],
         "dest": "flatpak-node/cache/esbuild",
         "only-arches": [
@@ -39145,16 +39340,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"cc5b3eafe2ec03888a528f9187925e47a9aa57f874b66b010c11c1330e57d89b\"",
-            "ln -s \"../SHASUMS256.txt-40.8.3\" \"cc5b3eafe2ec03888a528f9187925e47a9aa57f874b66b010c11c1330e57d89b/SHASUMS256.txt\""
-        ],
-        "dest": "flatpak-node/cache/electron"
-    },
-    {
-        "type": "shell",
-        "commands": [
-            "mkdir -p \"cc5b3eafe2ec03888a528f9187925e47a9aa57f874b66b010c11c1330e57d89b\"",
-            "ln -s \"../electron-v40.8.3-linux-arm64.zip\" \"cc5b3eafe2ec03888a528f9187925e47a9aa57f874b66b010c11c1330e57d89b/electron-v40.8.3-linux-arm64.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv42.3.0electron-v42.3.0-linux-arm64.zip\"",
+            "ln -s \"../electron-v42.3.0-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv42.3.0electron-v42.3.0-linux-arm64.zip/electron-v42.3.0-linux-arm64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -39164,8 +39351,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"cc5b3eafe2ec03888a528f9187925e47a9aa57f874b66b010c11c1330e57d89b\"",
-            "ln -s \"../electron-v40.8.3-linux-armv7l.zip\" \"cc5b3eafe2ec03888a528f9187925e47a9aa57f874b66b010c11c1330e57d89b/electron-v40.8.3-linux-armv7l.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv42.3.0electron-v42.3.0-linux-armv7l.zip\"",
+            "ln -s \"../electron-v42.3.0-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv42.3.0electron-v42.3.0-linux-armv7l.zip/electron-v42.3.0-linux-armv7l.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [
@@ -39175,41 +39362,8 @@
     {
         "type": "shell",
         "commands": [
-            "mkdir -p \"cc5b3eafe2ec03888a528f9187925e47a9aa57f874b66b010c11c1330e57d89b\"",
-            "ln -s \"../electron-v40.8.3-linux-x64.zip\" \"cc5b3eafe2ec03888a528f9187925e47a9aa57f874b66b010c11c1330e57d89b/electron-v40.8.3-linux-x64.zip\""
-        ],
-        "dest": "flatpak-node/cache/electron",
-        "only-arches": [
-            "x86_64"
-        ]
-    },
-    {
-        "type": "shell",
-        "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv40.8.3electron-v40.8.3-linux-arm64.zip\"",
-            "ln -s \"../electron-v40.8.3-linux-arm64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv40.8.3electron-v40.8.3-linux-arm64.zip/electron-v40.8.3-linux-arm64.zip\""
-        ],
-        "dest": "flatpak-node/cache/electron",
-        "only-arches": [
-            "aarch64"
-        ]
-    },
-    {
-        "type": "shell",
-        "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv40.8.3electron-v40.8.3-linux-armv7l.zip\"",
-            "ln -s \"../electron-v40.8.3-linux-armv7l.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv40.8.3electron-v40.8.3-linux-armv7l.zip/electron-v40.8.3-linux-armv7l.zip\""
-        ],
-        "dest": "flatpak-node/cache/electron",
-        "only-arches": [
-            "arm"
-        ]
-    },
-    {
-        "type": "shell",
-        "commands": [
-            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv40.8.3electron-v40.8.3-linux-x64.zip\"",
-            "ln -s \"../electron-v40.8.3-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv40.8.3electron-v40.8.3-linux-x64.zip/electron-v40.8.3-linux-x64.zip\""
+            "mkdir -p \"httpsgithub.comelectronelectronreleasesdownloadv42.3.0electron-v42.3.0-linux-x64.zip\"",
+            "ln -s \"../electron-v42.3.0-linux-x64.zip\" \"httpsgithub.comelectronelectronreleasesdownloadv42.3.0electron-v42.3.0-linux-x64.zip/electron-v42.3.0-linux-x64.zip\""
         ],
         "dest": "flatpak-node/cache/electron",
         "only-arches": [

--- a/net.cozic.joplin_desktop.yml
+++ b/net.cozic.joplin_desktop.yml
@@ -101,8 +101,8 @@ modules:
 
     sources:
       - type: archive
-        url: https://github.com/laurent22/joplin/archive/v3.6.14.tar.gz
-        sha256: b3a055bcd5c330705dcfd328b48e03118c153b2d8918cf25cfd8ea71d5bc1746
+        url: https://github.com/laurent22/joplin/archive/v3.7.18.tar.gz
+        sha256: 60eb34872a61efce325034ab1a052a0d37f9f0028b037d5482b1e649d8d63c4f
         x-checker-data:
           type: json
           url: https://api.github.com/repos/laurent22/joplin/releases/latest


### PR DESCRIPTION
Updated node sources and manifest to 3.7.18.

Note on build: The build succeeds locally if I temporarily allow network access, but I kept the manifest clean for this PR. Without network, it fails with an `EAI_AGAIN github.com` error during the `electron-builder` step because it tries to fetch the Electron 42.3.0 binary.

Could you provide guidance on the standard way to cache this specific Electron binary offline in this repo so the CI can pass?